### PR TITLE
Fix error handling in stringEntryBlock

### DIFF
--- a/src/Component/Block.elm
+++ b/src/Component/Block.elm
@@ -271,13 +271,21 @@ stringEntryBlock c label =
 
                                     Just t ->
                                         toType t ++ update
+
+                            error input =
+                                case c.fromString input of
+                                    Just _ ->
+                                        Nothing
+
+                                    Nothing ->
+                                        Just (c.onError input)
                         in
                         UI.textField
                             { msg = onUpdate
                             , id = Ref.toString stringRef
                             , label = label
                             , value = stringValue |> Maybe.withDefault (c.toString value)
-                            , error = Maybe.map c.onError stringValue
+                            , error = stringValue |> Maybe.andThen error
                             }
                     ]
             in


### PR DESCRIPTION
BUG FIX - The component playground would give a parse error for *any* string or float values entered by the user.