### PR TITLE
Unlabelled fixes, Add `withMsgF`

### DIFF
--- a/src/Component.elm
+++ b/src/Component.elm
@@ -1,6 +1,6 @@
 module Component exposing
     ( Block, BlockI, Builder, Component, ComponentRef, Library, Lookup, Msg, Preview, Ref, Type, View
-    , new, withComponent, withComponent_, withControl, withControl_, withMsg, withMsg2, withMsg3, withState, withStateF, withStateF_, withState_, withUnlabelled, withUnlabelledState, withUnlabelledStateF, withUnlabelledStateF_, withUnlabelledState_, withUnlabelled_, withUpdateF, fromPreview, map
+    , new, withComponent, withComponent_, withControl, withControl_, withMsg, withMsg2, withMsg3, withState, withStateF, withStateF_, withState_, withUnlabelled, withUnlabelledState, withUnlabelledStateF, withUnlabelledStateF_, withUnlabelledState_, withUnlabelled_, withUpdateF, withMsgF, fromPreview, map
     , previewBlock, identifier, list, list2, bool, int, float, string, oneOf, stringEntryBlock, custom
     , addVia, build, finish, finish_
     , toPortalPreview, toPreview
@@ -18,7 +18,7 @@ and exported here so that it is possible to write explicit type signatures.
 
 #Constructing Components
 
-@docs new, withComponent, withComponent_, withControl, withControl_, withMsg, withMsg2, withMsg3, withState, withStateF, withStateF_, withState_, withUnlabelled, withUnlabelledState, withUnlabelledStateF, withUnlabelledStateF_, withUnlabelledState_, withUnlabelled_, withUpdateF, fromPreview, map
+@docs new, withComponent, withComponent_, withControl, withControl_, withMsg, withMsg2, withMsg3, withState, withStateF, withStateF_, withState_, withUnlabelled, withUnlabelledState, withUnlabelledStateF, withUnlabelledStateF_, withUnlabelledState_, withUnlabelled_, withUpdateF, withMsgF, fromPreview, map
 
 #Blocks
 
@@ -205,6 +205,14 @@ withUpdateF :
     -> Component t (Msg t msg) y
 withUpdateF =
     Component.withUpdateF
+
+
+withMsgF :
+    ((msg -> Msg t msg) -> x -> y)
+    -> Component t (Msg t msg) x
+    -> Component t (Msg t msg) y
+withMsgF =
+    Component.withMsgF
 
 
 withComponent : String -> (Library t msg -> String -> BlockI t i b) -> i -> Component t msg (b -> a) -> Component t msg a

--- a/src/Component/Component.elm
+++ b/src/Component/Component.elm
@@ -18,6 +18,7 @@ module Component.Component exposing
     , withMsg
     , withMsg2
     , withMsg3
+    , withMsgF
     , withState
     , withStateF
     , withUnlabelled
@@ -175,6 +176,24 @@ withUpdateF block f =
                         )
                 )
                 x
+
+
+withMsgF :
+    ((msg -> Msg t msg) -> x -> y)
+    -> Component t (Msg t msg) x
+    -> Component t (Msg t msg) y
+withMsgF f (Component p) =
+    Component <|
+        { value =
+            \lib lookup ->
+                let
+                    helper =
+                        f (\msg -> Update (always ( [], msg )))
+                in
+                State.map helper (p.value lib lookup)
+        , controls = p.controls
+        , reference = p.reference
+        }
 
 
 withControl : String -> (String -> BlockI t i a) -> Component t msg (a -> b) -> Component t msg b


### PR DESCRIPTION
### Bug Fix

Unlabelled and labelled controls/state were previously exactly the same. This bug had gone unnoticed because we usually only used `Component.identifier` (which has no controls) as unlabelled. This PR fixes this by adding a variant `withHelperUnlabelled` of the existing `withHelper` for unlabelled state.

### New Component Function

Previously, constructing a custom message that could depend on one or more arguments was only possible using one of the `with...F` functions, all of which use some state. If we didn't want any state, we would have to use some unnecessary dummy block anyway and just ignore everything from it. `withMsgF` solves this by not exposing the need for any state to the library user, and still allows very general messages to be constructed in the same way that `withUpdateF` and friends would.