### PR TITLE
Effectful update support

### DIFF
--- a/src/Component.elm
+++ b/src/Component.elm
@@ -5,7 +5,7 @@ module Component exposing
     , previewBlock, identifier, list, list2, bool, int, float, string, oneOf, stringEntryBlock, custom
     , addVia, build, finish, finish_
     , toPortalPreview, toPreview
-    , toComponentMsg
+    , toComponentMsg, withDefault
     )
 
 {-| TODO: write a description of the module, and write descriptions for each section of the docs
@@ -269,7 +269,7 @@ finish_ =
     Block.finishI identity
 
 
-identifier : BlockI t Ref String
+identifier : BlockI t String String
 identifier =
     Block.identifier
 
@@ -326,3 +326,13 @@ bool =
 custom : (t -> Maybe a) -> (a -> t) -> a -> BlockI t a a
 custom =
     Block.custom
+
+{-| Override the default value for a block. Use this to get a stable default
+to be referenced in multiple places. Use this when using
+Component.Application.updateAt.
+
+withDefault is used to set the initial value when building Components with
+withControl, withState etc., but not when using withControl_, withState_, etc.
+-}
+withDefault : i -> Block.BlockI t i a -> Block.BlockI t i a
+withDefault = Block.withDefault

--- a/src/Component/Block.elm
+++ b/src/Component/Block.elm
@@ -299,7 +299,7 @@ stringEntryBlock c label =
     Block <| State.map inner (Ref.nested (State.map2 Tuple.pair Ref.take Ref.take))
 
 
-identifier : BlockI t Ref String
+identifier : BlockI t String String
 identifier =
     Ref.take
         |> State.map
@@ -307,8 +307,8 @@ identifier =
                 { fromType = \_ default _ -> default
                 , toType = \_ -> []
                 , controls = \_ -> []
-                , default = ref
-                , map = always Ref.toString
+                , default = Ref.toString ref
+                , map = always identity
                 }
             )
         |> Block


### PR DESCRIPTION
This PR adds `updateAt` which allows for updating a value at a `Ref`. This kind of breaks the abstraction and makes it possible to use the component library unsafely.

Ideally there'd be better update support for a component, and that makes this similar to stories support which had been considered too. In this situation, we'd end up with a `model` type for each component, which would make it trivial to have an `update` function, and then stories would be choosing a model from a list of available models.

If we had the model and update types we could remove `updateAt` since there'd be trivial ways to update a value in the component's `update` function.