### PR TITLE
PW-886: Playground shell redesign (sidebar, Inspector, Phosphor, component-aware tokens, page structure)

### DIFF
--- a/docs/inspector-theming-and-injection.md
+++ b/docs/inspector-theming-and-injection.md
@@ -1,0 +1,118 @@
+# Inspector theming & control injection
+
+The Inspector is "just another consumer" of the design system: the interface
+that configures a component should look and behave like the components it
+configures. This document describes how that is achieved without ever coupling
+this generic library to any one host application's component code.
+
+## Two layers, one rule
+
+1. **Generic playground library (this repo).** App-agnostic control
+   *primitives* (`Component.Ui.textField` / `select` / `button`). They are
+   **themeable** and, in future, **injectable**. They must never import a host
+   application's components.
+2. **Host application (e.g. Planwisely / sage).** May supply its own production
+   controls to the Inspector through an integration layer it owns.
+
+**Hard rule:** dependencies only ever point host → library. `component-playground`
+must not depend on `Planwisely`'s `UI.*` (or any host) modules. Solving the
+"make the Inspector match production" problem by importing host components would
+break the library's generic purpose and is not allowed.
+
+## Where we are now (short-term: theming)
+
+The Inspector chrome and controls are styled through the injected shell
+stylesheet (`shellStylesheet` in `Component.Application`) plus the `ds*` design
+constants. Control box chrome and every interaction state are token-driven via a
+`.cp-control` ruleset (border, radius, fill, hover, brand-blue focus ring + glow,
+disabled), so text fields and selects match the search field and the rest of the
+Inspector. Typography stays `Theme`-driven.
+
+A host aligns the look by:
+
+- overriding the `Theme` fields it owns (`fontFamily`, `textColor`,
+  `mutedTextColor`, font sizes/weights, `errorColor`, `backgroundColor`,
+  `dividerColor`, sidebar slots), and
+- (next step) the `ds*` constants being **promoted into the `Theme`** as proper
+  control tokens — `accentColor`, `controlSurface`, `controlBorder`,
+  `controlBorderHover`, `controlRadius`, `controlPadding`, `focusRing`,
+  `controlDisabledSurface`, `controlHeight*` — so the box chrome is fully host-
+  controlled rather than carried by in-library constants. This keeps the
+  library generic while letting Planwisely map every value to its `--pw-*`
+  tokens.
+
+## Where we are going (longer-term: injection)
+
+Theming makes the library's own primitives *look* like production. Injection
+lets the host render the Inspector with its *actual* production components, so
+behaviour, accessibility and states are literally the same code as ship to
+users — true self-consumption — still with no reverse dependency.
+
+### Recommended API shape
+
+Add an optional control-renderer slot to the application config (carried on the
+`Theme`, or a sibling `config` record). The library defines the *interface* and
+ships a default implementation built from `Component.Ui`; the host may override.
+
+```elm
+type alias ControlRenderers msg =
+    { textField : TextFieldConfig msg -> Html msg
+    , select : SelectConfig msg -> Html msg
+    , toggle : ToggleConfig msg -> Html msg
+    , number : NumberConfig msg -> Html msg
+    -- …segmented, dateField, timeField as they are needed
+    }
+
+-- Config records are plain data the library already has at each control site:
+type alias SelectConfig msg =
+    { id : String
+    , label : String
+    , value : String
+    , options : List { label : String, value : String }
+    , onChange : String -> msg
+    , disabled : Bool
+    }
+
+-- The library's fallback — its own primitives, used when the host injects nothing:
+defaultControlRenderers : Theme -> ControlRenderers msg
+```
+
+Control rendering then calls `renderers.select {...}` instead of `Ui.select`
+directly, where `renderers` comes from the host config (falling back to
+`defaultControlRenderers theme`). The data passed is exactly what the controls
+already carry today (`Component.Control` already builds `id`/`label`/`value`/
+`options`/`onChange`).
+
+### Where Planwisely provides the controls
+
+In the host app (`sage`, `js/src/ComponentPlayground/Main.elm`), where the
+`Theme`/config is already constructed for `Component.Application.init`,
+Planwisely passes a `ControlRenderers` whose functions wrap its production
+components:
+
+```elm
+planwiselyControls : ControlRenderers msg
+planwiselyControls =
+    { select = \c -> UI.Dropdown.view { … from c … }
+    , textField = \c -> UI.TextInput.field { … from c … }
+    , toggle = \c -> UI.Switch.viewWithSize Switch.Medium { … from c … }
+    , number = \c -> UI.IncrementalInput.view { … from c … }
+    }
+```
+
+The library imports none of this; the host plugs its components in through the
+interface the library exposes. The dependency arrow stays host → library, and
+the Inspector becomes the largest integration-test surface for the real
+controls.
+
+## Adoption order
+
+1. ✅ Theme the existing primitives so the Inspector is visually compliant
+   (done — `.cp-control` + shell stylesheet).
+2. Promote the `ds*` constants into `Theme` control tokens (fully host-driven
+   look).
+3. Introduce `ControlRenderers` with a `Component.Ui`-based default.
+4. Planwisely supplies its production renderers from `ComponentPlayground.Main`.
+5. Expand coverage in the priority order: dropdowns → multi-selects → text
+   fields → text areas → toggles → checkboxes → radios → segmented → number →
+   date → time.

--- a/docs/stateful-control-renderers.md
+++ b/docs/stateful-control-renderers.md
@@ -1,0 +1,176 @@
+# Spec: stateful host-rendered Inspector controls
+
+Status: **proposal / not implemented.** This note specs the follow-up to the
+`ControlRenderers` proof (`docs/inspector-theming-and-injection.md`). It is the
+plan for letting a host render Inspector controls that need their own UI state —
+chiefly a custom dropdown with an open/closed menu — without breaking the
+generic library or the standalone fallback.
+
+## 1. What `ControlRenderers` supports today
+
+`ControlRenderers msg` currently exposes one renderer:
+
+```elm
+type alias SelectConfig msg =
+    { id : String
+    , label : String
+    , value : String
+    , options : List { label : String, value : String }
+    , onChange : String -> msg
+    }
+
+type alias ControlRenderers msg =
+    { select : SelectConfig msg -> Html msg }
+```
+
+It is **stateless by construction**. The library owns the only state that
+exists — the control's *value* — in its `Lookup` (keyed by the control's `Ref`).
+On every render it reads the current value, hands the renderer pure data, and
+the renderer's only output channel is `onChange : String -> msg`, which commits
+a new value. The renderer holds nothing between renders. Injection is via the
+`Library` (threaded at build) with `Application.initWith`; `default` provides a
+fallback built from `Component.Ui.select`, so the library still works with no
+host renderers.
+
+## 2. Why native `<select>` is enough for the proof but not a real dropdown
+
+The proof renders a native `<select>`. That works precisely *because the browser
+owns all the interaction state*:
+
+- **open/closed** menu — the OS opens and closes the popup;
+- **active/highlighted option** during keyboard nav — the OS tracks it;
+- **the menu surface itself** — drawn by the OS, outside the DOM.
+
+So a native select needs no app state, and value-only `onChange` is sufficient.
+
+A real Planwisely dropdown renders **its own menu surface in the DOM** so it can
+carry the design system (tokens, spacing, check marks, group headers, the purple
+focus glow, etc.). The moment the menu is app-drawn, the app must track:
+
+- whether the menu is open,
+- which option is keyboard-active,
+- focus / typeahead.
+
+None of that fits a value-only protocol. Consequences with today's API: the open
+menu can't be themed, and the dropdown can't behave as a controlled component
+(open, arrow-key through options, select, close on outside-click). This is the
+core finding: **value updates alone are insufficient when the host control owns
+internal UI state.**
+
+## 3. What state the protocol must carry
+
+A new, explicitly *UI* state — distinct from the control's stored value:
+
+| State | Type | Why |
+|---|---|---|
+| open | `Bool` | menu visibility |
+| active option | `Maybe Int` | keyboard highlight for arrow-key nav |
+| (optional) typeahead | `String` | type-to-find buffer |
+
+And the events to mutate it, alongside the existing value commit:
+
+- `setOpen : Bool -> msg` (or `toggleOpen`)
+- `setActive : Maybe Int -> msg`
+- `onChange : String -> msg` — unchanged; commits the value (and typically closes)
+
+Crucially, the setters must feed a **library-owned UI-state store**, not the
+component's value. That requires the control-update channel to carry a *UI-state
+update* kind in addition to the existing value updates — see §5.
+
+Keyboard and outside-click handling: the library should own the *policy* (Esc
+closes, Enter selects the active option, click-outside closes, only one menu open
+at a time) over the store, while the host renderer owns the *visuals*. This keeps
+behaviour consistent and prevents every host control re-implementing it.
+
+## 4. Per-control scoping
+
+The library already allocates a unique `Ref` per control. Scope UI state by that
+`Ref`:
+
+```elm
+-- in the Application Model
+controlUi : Dict Ref ControlUiState
+```
+
+Each renderer invocation receives **only its own slice** plus setters that are
+pre-scoped to its `Ref`, so toggling one dropdown cannot affect another, and the
+"single open at a time" policy is just a transform over this dict (close all
+others when one opens). State is keyed by identity the library already owns, so
+nothing new needs to be threaded through the control tree.
+
+## 5. Doing it without breaking standalone fallback
+
+Two compatibility rules:
+
+1. **Additive, opt-in renderer.** Keep the existing stateless `select`. Add a
+   *separate optional* stateful slot. A host that provides nothing, or only the
+   stateless `select`, is unaffected; `default` stays stateless (native select).
+   The library only allocates/threads `controlUi` for controls whose stateful
+   renderer is actually present.
+
+   ```elm
+   type alias ControlRenderers msg =
+       { select : SelectConfig msg -> Html msg                       -- today
+       , selectStateful : Maybe (StatefulSelectConfig msg -> Html msg) -- opt-in
+       }
+   ```
+
+2. **Extend the update channel, don't replace it.** The setters return the same
+   `msg` the control system already dispatches, widened with a UI-state kind that
+   `Application.update` routes to the per-`Ref` `controlUi` store (rather than to
+   the value `Lookup`). Existing value updates are untouched, so stateless
+   controls and the fallback render exactly as now.
+
+## Smallest API sketch
+
+```elm
+-- Library-owned, per-control UI state (keyed by Ref in the Model).
+type alias ControlUiState =
+    { open : Bool, active : Maybe Int }
+
+-- This control's slice + setters, pre-scoped to its Ref. The setters' msgs
+-- flow to the library's controlUi store, not the value Lookup.
+type alias ControlUiEnv msg =
+    { state : ControlUiState
+    , setOpen : Bool -> msg
+    , setActive : Maybe Int -> msg
+    }
+
+type alias StatefulSelectConfig msg =
+    { id : String
+    , label : String
+    , value : String
+    , options : List { label : String, value : String }
+    , onChange : String -> msg   -- commit value (+ library closes the menu)
+    , ui : ControlUiEnv msg      -- NEW: open/active + scoped setters
+    }
+```
+
+The library: keeps `controlUi : Dict Ref ControlUiState`; when a control has a
+`selectStateful` renderer, looks up its slice, builds a `ControlUiEnv` with
+setters bound to that `Ref`, and renders via the host function; `Application.update`
+applies UI-state msgs to the dict (and enforces single-open / Esc / outside-click
+policy). No stateful renderer → unchanged stateless path.
+
+## 6. Migration path
+
+- **Phase 0 — done.** Stateless `ControlRenderers` proof: host-rendered select,
+  library fallback preserved.
+- **Phase 1 — protocol.** Add `controlUi : Dict Ref ControlUiState`, the UI-state
+  update kind in `Application.update`, the `ControlUiEnv`, and `selectStateful`.
+  Library owns open/active + the close policies. Fallback stays stateless.
+- **Phase 2 — real dropdown.** Planwisely supplies `selectStateful` backed by its
+  production `UI.Dropdown` (styled open menu). Validate rest / hover / focus /
+  **open** / active / selected / keyboard.
+- **Phase 3 — generalise.** Reuse the per-`Ref` UI-state pattern for the other
+  *stateful* controls (multi-select, palette, date/time pickers). Stateless
+  controls (text field, toggle, checkbox, number) stay on the simple renderer —
+  no UI state, no extra cost.
+- **Phase 4 — default.** Once parity and host coverage are broad, make the host
+  renderers the default path and retire native fallbacks where a host always
+  provides them; keep `default` for standalone use of the library.
+
+### Out of scope / explicitly deferred
+
+Control radius (now 4px, `radiusSm`) is a separate, already-decided token change
+and is not part of this protocol work.

--- a/src/Component.elm
+++ b/src/Component.elm
@@ -1,8 +1,9 @@
 module Component exposing
     ( Component, Component_, ComponentInstance, ComponentRef, Control, Control_
-    , Preset, Update, View
+    , Preset, Token, TokenGroup, Update, View
     , component, component_, componentWithPortals, componentWithPortals_
     , preset, withPresets
+    , tokenGroup, withTokens
     , toRef
     )
 
@@ -32,7 +33,7 @@ Build interactive playgrounds for your UI components in three steps:
 
 # Supporting Types
 
-@docs Preset, Update, View
+@docs Preset, Token, TokenGroup, Update, View
 
 
 # Component Constructors
@@ -43,6 +44,11 @@ Build interactive playgrounds for your UI components in three steps:
 # Presets
 
 @docs preset, withPresets
+
+
+# Design tokens
+
+@docs tokenGroup, withTokens
 
 
 # References
@@ -116,6 +122,21 @@ type alias Preset t i =
     Internal.Preset t i
 
 
+{-| A category of design tokens a component consumes (e.g. Colour, Motion),
+with the specific tokens within it. Build with `tokenGroup` and attach with
+`withTokens`.
+-}
+type alias TokenGroup =
+    Internal.TokenGroup
+
+
+{-| A single design token: its name (e.g. `pw-ink`) and resolved value
+(e.g. `#0A0F22`).
+-}
+type alias Token =
+    Internal.Token
+
+
 {-| Update type for component state changes. Tagged with the owning
 ComponentInstance so Application.update can dispatch correctly.
 -}
@@ -165,6 +186,7 @@ component c =
         , controls = c.controls
         , view = \_ m setter -> ( c.view m setter, Dict.empty )
         , presets = []
+        , tokens = []
         }
 
 
@@ -185,6 +207,7 @@ componentWithPortals c =
         , controls = c.controls
         , view = \_ m setter -> c.view m setter
         , presets = []
+        , tokens = []
         }
 
 
@@ -205,6 +228,7 @@ component_ c =
         , controls = c.controls
         , view = \i m setter -> ( c.view i m setter, Dict.empty )
         , presets = []
+        , tokens = []
         }
 
 
@@ -224,6 +248,7 @@ componentWithPortals_ c =
         , controls = c.controls
         , view = c.view
         , presets = []
+        , tokens = []
         }
 
 
@@ -262,6 +287,43 @@ their controls.
 withPresets : List (Preset t i) -> Component_ e t i m msg -> Component_ e t i m msg
 withPresets ps (Component_ c) =
     Component_ { c | presets = ps }
+
+
+
+-- DESIGN TOKENS
+
+
+{-| Build a design-token category from a name and its `( name, value )` token
+pairs:
+
+    Component.tokenGroup "Colour"
+        [ ( "pw-ink", "#0A0F22" )
+        , ( "pw-surface", "#FEFEFE" )
+        ]
+
+-}
+tokenGroup : String -> List ( String, String ) -> TokenGroup
+tokenGroup category tokens =
+    { category = category
+    , tokens = List.map (\( name, value ) -> { name = name, value = value }) tokens
+    }
+
+
+{-| Declare the design tokens a component consumes, grouped by category. The
+Inspector renders exactly these groups for the selected component — and only
+these — so the token reference is component-aware rather than a global list.
+Categories a component does not consume are simply omitted.
+
+    button
+        |> Component.withTokens
+            [ Component.tokenGroup "Colour" [ ( "pw-ink", "#0A0F22" ) ]
+            , Component.tokenGroup "Motion" [ ( "ease-out", "100ms" ) ]
+            ]
+
+-}
+withTokens : List TokenGroup -> Component_ e t i m msg -> Component_ e t i m msg
+withTokens ts (Component_ c) =
+    Component_ { c | tokens = ts }
 
 
 

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -97,7 +97,7 @@ type alias Model t e =
     , inspectorOpen : Bool
     , activeInspector : Maybe String
     , collapsedGroups : Set String
-    , collapsedTokens : Set String
+    , expandedTokens : Set String
     , theme : Theme
     }
 
@@ -367,20 +367,13 @@ init theme playgrounds url =
     , activeInspector = Nothing
     , collapsedGroups = Set.empty
 
-    -- Design-token reference groups start collapsed: they are a read-only
-    -- vocabulary, not per-component detection, so they stay out of the way
-    -- until a reader opens one.
-    , collapsedTokens = Set.fromList tokenGroupNames
+    -- Design-token groups start collapsed: the set tracks which categories the
+    -- reader has explicitly opened, so an empty set means every group is closed
+    -- by default (and it copes with each component exposing a different set of
+    -- categories).
+    , expandedTokens = Set.empty
     , theme = theme
     }
-
-
-{-| The design-token reference group names, in display order. Used to seed
-`collapsedTokens` (all closed by default) and to render the reference itself.
--}
-tokenGroupNames : List String
-tokenGroupNames =
-    [ "Typography", "Colour", "Radius", "Elevation", "Spacing", "Motion" ]
 
 
 urlToPage : Url.Url -> Maybe String
@@ -443,7 +436,7 @@ update msg model =
             ( { model | collapsedGroups = toggleMember groupId model.collapsedGroups }, [] )
 
         ToggleTokenGroup groupName ->
-            ( { model | collapsedTokens = toggleMember groupName model.collapsedTokens }, [] )
+            ( { model | expandedTokens = toggleMember groupName model.expandedTokens }, [] )
 
 
 toggleMember : comparable -> Set comparable -> Set comparable
@@ -569,6 +562,7 @@ type alias Inspectable t e =
     { id : String
     , name : String
     , controls : List (Html (Msg t e))
+    , tokens : List Internal.TokenGroup
     }
 
 
@@ -591,6 +585,7 @@ pageInspectables model =
                             { id = meta.id
                             , name = meta.name
                             , controls = List.map (Html.map ComponentUpdate) (internals.controls theme lookup)
+                            , tokens = internals.tokens
                             }
 
                     ProcessedPresets meta _ internals ->
@@ -598,6 +593,7 @@ pageInspectables model =
                             { id = meta.id
                             , name = meta.name
                             , controls = List.map (Html.map ComponentUpdate) (internals.innerControls theme lookup)
+                            , tokens = internals.tokens
                             }
 
                     _ ->
@@ -643,9 +639,12 @@ shellStylesheet =
                 , ".cp-nav-row:focus-visible{outline:2px solid " ++ dsAccent ++ ";outline-offset:-2px;}"
                 , ".cp-nav-row.is-active{background:" ++ dsBrandBlue50 ++ ";}"
                 , ".cp-nav-row.is-active:hover{background:" ++ dsBrandBlue50 ++ ";}"
-                , ".cp-nav-icon{color:" ++ dsInk4 ++ ";transition:color .12s ease;}"
-                , ".cp-nav-row:hover .cp-nav-icon{color:" ++ dsInk3 ++ ";}"
+                , ".cp-nav-icon{color:" ++ dsInk2 ++ ";transition:color .12s ease;}"
+                , ".cp-nav-row:hover .cp-nav-icon{color:" ++ dsInk ++ ";}"
                 , ".cp-nav-row.is-active .cp-nav-icon{color:" ++ dsAccent ++ ";}"
+                , ".cp-nav-row.contains-active .cp-nav-icon{color:" ++ dsAccent ++ ";}"
+                , ".cp-nav-chevron{color:" ++ dsInk4 ++ ";transition:color .12s ease;}"
+                , ".cp-nav-row:hover .cp-nav-chevron{color:" ++ dsInk3 ++ ";}"
                 , ".cp-icon-btn{transition:background-color .12s ease,color .12s ease;}"
                 , ".cp-icon-btn:hover{background:" ++ dsSurfaceAlt ++ ";color:" ++ dsInk ++ ";}"
                 , ".cp-trigger{transition:background-color .12s ease,box-shadow .12s ease,border-color .12s ease;}"
@@ -825,7 +824,7 @@ viewGroupRow model depth item isOpen containsActive =
 
         chevron =
             Html.span
-                [ Html.Attributes.class "cp-nav-icon", Ui.style "display" "inline-flex" ]
+                [ Html.Attributes.class "cp-nav-chevron", Ui.style "display" "inline-flex" ]
                 [ iconBox 13
                     (if isOpen then
                         Ui.phosphorCaretDown ""
@@ -862,9 +861,18 @@ viewGroupRow model depth item isOpen containsActive =
 
     else
         -- Nested, expandable category (e.g. Button). Carries a leading glyph and,
-        -- when it contains the active page, strong ink so the path stands out.
+        -- when it contains the active page, an accent icon + label so the path to
+        -- the selection reads as one highlighted group.
         Ui.button theme
-            [ Html.Attributes.class "cp-nav-row"
+            [ Html.Attributes.class
+                ("cp-nav-row"
+                    ++ (if containsActive then
+                            " contains-active"
+
+                        else
+                            ""
+                       )
+                )
             , Ui.style "display" "flex"
             , Ui.style "align-items" "center"
             , Ui.style "justify-content" "space-between"
@@ -874,13 +882,12 @@ viewGroupRow model depth item isOpen containsActive =
             , Ui.style "padding-left" (navIndent depth)
             , Ui.style "padding-right" "10px"
             , Ui.style "border-radius" dsRadiusMd
-            , Ui.style "border-left" "3px solid transparent"
             , Ui.style "font-family" theme.fontFamily
             , Ui.style "font-size" "14px"
             , Ui.style "font-weight" "600"
             , Ui.style "color"
                 (if containsActive then
-                    dsInk
+                    dsAccent
 
                  else
                     dsInk2
@@ -943,15 +950,6 @@ viewPageLink model depth meta =
         , Ui.style "padding-left" (navIndent depth)
         , Ui.style "padding-right" "10px"
         , Ui.style "border-radius" dsRadiusMd
-        , Ui.style "border-left"
-            ("3px solid "
-                ++ (if isActive then
-                        dsAccent
-
-                    else
-                        "transparent"
-                   )
-            )
         , Ui.style "font-family" theme.fontFamily
         , Ui.style "font-size" "14px"
         , Ui.style "font-weight"
@@ -1623,6 +1621,11 @@ viewInspectorPanel model inspectables =
             active
                 |> Maybe.map .controls
                 |> Maybe.withDefault []
+
+        tokenGroups =
+            active
+                |> Maybe.map .tokens
+                |> Maybe.withDefault []
     in
     Html.div [ Html.Attributes.class "cp-inspector" ]
         [ inspectorHeader theme
@@ -1635,7 +1638,7 @@ viewInspectorPanel model inspectables =
                   else
                     []
                 , [ inspectorSection theme "Component Settings" Nothing controls
-                  , inspectorSection theme "Design Tokens" (Just "Read-only reference") [ tokenReference model ]
+                  , inspectorSection theme "Design Tokens" (Just "Used by this component") [ tokenReference model tokenGroups ]
                   ]
                 ]
             )
@@ -1822,34 +1825,39 @@ inspectorSection theme title caption content =
         )
 
 
-{-| A read-only reference of the design-system token vocabulary, grouped into
-collapsible categories. The framework treats components as opaque render
-functions, so this is the token vocabulary — not a per-component usage filter.
+{-| The Design Tokens reference for the selected component. Each group is the
+component's own declared token usage (via `Component.withTokens`), so the list
+varies by component and never shows a category the component does not consume.
+Groups are collapsed by default and read-only. When a component declares no
+token metadata, a short note is shown rather than a misleading global list.
 -}
-tokenReference : Model t e -> Html (Msg t e)
-tokenReference model =
-    Html.div
-        [ Ui.style "display" "flex"
-        , Ui.style "flex-direction" "column"
-        , Ui.style "gap" dsSpace2
-        ]
-        [ tokenGroup model "Typography" [ ( "text-xs", "12px" ), ( "text-sm", "14px" ), ( "text-base", "16px" ), ( "text-lg", "18px" ) ]
-        , tokenGroup model "Colour" [ ( "pw-surface", dsSurface ), ( "pw-surface-alt", dsSurfaceAlt ), ( "pw-ink", dsInk ), ( "pw-ink-3", dsInk3 ), ( "pw-line", dsLine ) ]
-        , tokenGroup model "Radius" [ ( "rounded-sm", dsRadiusSm ), ( "rounded-md", dsRadiusMd ), ( "rounded-lg", dsRadiusLg ) ]
-        , tokenGroup model "Elevation" [ ( "shadow-1", "" ), ( "shadow-2", "" ), ( "shadow-4", "" ) ]
-        , tokenGroup model "Spacing" [ ( "space-2", "8px" ), ( "space-3", "12px" ), ( "space-4", "16px" ) ]
-        , tokenGroup model "Motion" [ ( "ease-out", "150ms" ), ( "ease-spring", "200ms" ) ]
-        ]
+tokenReference : Model t e -> List Internal.TokenGroup -> Html (Msg t e)
+tokenReference model groups =
+    if List.isEmpty groups then
+        Html.span
+            [ Ui.style "font-family" model.theme.fontFamily
+            , Ui.style "font-size" "12px"
+            , Ui.style "color" dsInk4
+            ]
+            [ Html.text "Token usage isn’t documented for this component yet." ]
+
+    else
+        Html.div
+            [ Ui.style "display" "flex"
+            , Ui.style "flex-direction" "column"
+            , Ui.style "gap" dsSpace2
+            ]
+            (List.map (tokenGroupView model) groups)
 
 
-tokenGroup : Model t e -> String -> List ( String, String ) -> Html (Msg t e)
-tokenGroup model groupName rows =
+tokenGroupView : Model t e -> Internal.TokenGroup -> Html (Msg t e)
+tokenGroupView model group =
     let
         theme =
             model.theme
 
-        collapsed =
-            Set.member groupName model.collapsedTokens
+        expanded =
+            Set.member group.category model.expandedTokens
     in
     Html.div
         [ Ui.style "display" "flex"
@@ -1868,30 +1876,41 @@ tokenGroup model groupName rows =
             , Ui.style "font-size" "11px"
             , Ui.style "font-weight" "600"
             , Ui.style "color" dsInk2
-            , Ui.onClick (ToggleTokenGroup groupName)
+            , Ui.onClick (ToggleTokenGroup group.category)
             ]
-            [ Html.text groupName
+            [ Html.span
+                [ Ui.style "display" "flex"
+                , Ui.style "align-items" "center"
+                , Ui.style "gap" "6px"
+                ]
+                [ Html.text group.category
+                , Html.span
+                    [ Ui.style "font-weight" "500"
+                    , Ui.style "color" dsInk4
+                    ]
+                    [ Html.text (String.fromInt (List.length group.tokens)) ]
+                ]
             , Html.span [ Ui.style "color" dsInk4 ]
                 [ iconBox 14
-                    (if collapsed then
-                        Ui.phosphorCaretRight ""
+                    (if expanded then
+                        Ui.phosphorCaretDown ""
 
                      else
-                        Ui.phosphorCaretDown ""
+                        Ui.phosphorCaretRight ""
                     )
                 ]
             ]
-            :: (if collapsed then
-                    []
+            :: (if expanded then
+                    List.map (tokenRow theme) group.tokens
 
                 else
-                    List.map (tokenRow theme) rows
+                    []
                )
         )
 
 
-tokenRow : Theme -> ( String, String ) -> Html (Msg t e)
-tokenRow theme ( name, value ) =
+tokenRow : Theme -> Internal.Token -> Html (Msg t e)
+tokenRow theme { name, value } =
     Html.div
         [ Ui.style "display" "flex"
         , Ui.style "align-items" "center"

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -1594,7 +1594,12 @@ playgroundShell topItems inner =
         , Ui.style "border" ("1px solid " ++ dsLine)
         , Ui.style "border-radius" dsRadiusLg
         , Ui.style "box-shadow" dsShadow2
-        , Ui.style "overflow" "hidden"
+
+        -- Visible (not hidden) so an open dropdown / popover menu inside the live
+        -- component can float out of the callout instead of being clipped. The
+        -- card's own background still respects the radius; children are padded in
+        -- and carry no full-bleed fill, so corners stay clean.
+        , Ui.style "overflow" "visible"
         ]
         (topItems
             ++ [ Html.div
@@ -1617,9 +1622,14 @@ playgroundCard maybeTabBar inner =
 {-| A reference / specimen block (variant matrices, size charts). Unlike the
 Playground card — a contained live panel with border, radius and elevation — the
 specimen section reads as an open, table-like reference: no filled box, just a
-hairline rule above it for separation and room to scroll wide content. The
-contrast between the two is what tells a contained live component apart from a
-flat specimen sheet.
+hairline rule above it for separation.
+
+Overflow is left **visible** rather than `overflow-x: auto`: an `auto` box is a
+scroll container, which clips an open dropdown / popover specimen vertically.
+Specimens lay their content out with wrapping rows, so they don't need the
+horizontal-scroll affordance; any genuinely wide specimen should wrap its own
+content in a scroll container.
+
 -}
 specimenBlock : Html (Msg t e) -> Html (Msg t e)
 specimenBlock html =
@@ -1627,7 +1637,7 @@ specimenBlock html =
         [ Ui.style "margin-top" "20px"
         , Ui.style "padding-top" "20px"
         , Ui.style "border-top" ("1px solid " ++ dsLine2)
-        , Ui.style "overflow-x" "auto"
+        , Ui.style "overflow" "visible"
         ]
         [ html ]
 

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -1911,11 +1911,14 @@ viewInspectorPanel model inspectables =
 inspectorHeader : Theme -> Html (Msg t e)
 inspectorHeader theme =
     Html.div
+        -- Height matches the top ribbon (56px) so the two bottom hairlines line
+        -- up into one continuous rule across the ribbon and the open panel.
         [ Ui.style "display" "flex"
         , Ui.style "align-items" "center"
         , Ui.style "justify-content" "space-between"
         , Ui.style "flex-shrink" "0"
-        , Ui.style "padding" "16px 20px"
+        , Ui.style "height" "56px"
+        , Ui.style "padding" "0 20px"
         , Ui.style "border-bottom" ("1px solid " ++ dsLine)
         ]
         [ Html.span

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -661,6 +661,18 @@ shellStylesheet =
                 , ".cp-search{transition:border-color .12s ease,box-shadow .12s ease;}"
                 , ".cp-search:focus-within{border-color:" ++ dsBrandBlue ++ ";box-shadow:0 0 0 3px " ++ dsBrandBlue50 ++ ";}"
 
+                -- Inspector controls (text fields, selects/booleans). The box
+                -- chrome and every interaction state live here so they are
+                -- token-driven and consistent with the search field; the
+                -- control elements carry `cp-control` and set only their own
+                -- typography/layout inline. Error state keeps its inline border,
+                -- which (being inline) still wins over these class rules.
+                , ".cp-control{border:1px solid " ++ dsLine ++ ";border-radius:" ++ dsRadiusMd ++ ";background:" ++ dsSurface ++ ";padding:7px 10px;transition:border-color .12s ease,box-shadow .12s ease;}"
+                , ".cp-control:hover{border-color:" ++ dsBorderHover ++ ";}"
+                , ".cp-control:focus,.cp-control:focus-visible{outline:none;border-color:" ++ dsBrandBlue ++ ";box-shadow:0 0 0 3px " ++ dsBrandBlue50 ++ ";}"
+                , ".cp-control:disabled{background:" ++ dsSurfaceAlt ++ ";color:" ++ dsInk4 ++ ";cursor:not-allowed;}"
+                , ".cp-control::placeholder{color:" ++ dsInk4 ++ ";}"
+
                 -- The in-field clear control: a glyph that recolours on hover /
                 -- focus rather than gaining its own button chrome, so it reads as
                 -- part of the input.
@@ -1783,6 +1795,11 @@ dsLine =
 dsLine2 : String
 dsLine2 =
     "#EEF0F3"
+
+
+dsBorderHover : String
+dsBorderHover =
+    "#B8C0CC"
 
 
 dsInk : String

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -1352,12 +1352,15 @@ referenceSection model rest =
         referenceHeading model.theme :: viewFramesList model rest
 
 
-{-| The "Reference" section heading — a first-class peer to the Playground
-section, opening the supporting documentation below the live component. It
-mirrors the Playground header row exactly (icon + label, same size / weight /
-colour) so the two sections read at the same hierarchy level; the everything
-under it (variant charts, specimens, usage and behaviour notes) reads as its
-subsections.
+{-| The "Reference" section heading — the primary documentation heading for the
+page, opening the supporting material below the live Playground component.
+
+It is a full **H2** from the type scale (24 / 600), so it clearly dominates the
+content headings beneath it (variant charts, specimens, usage and behaviour
+notes), which render one step down at H4 (see `sectionLabel`). The book-open
+icon pairs it with the Playground flask while the larger type makes it read as
+the section owner, not a peer label.
+
 -}
 referenceHeading : Theme -> Html (Msg t e)
 referenceHeading theme =
@@ -1366,15 +1369,15 @@ referenceHeading theme =
         , Ui.style "align-items" "center"
         , Ui.style "gap" dsSpace2
         , Ui.style "margin-top" "48px"
-        , Ui.style "margin-bottom" dsSpace2
+        , Ui.style "margin-bottom" dsSpace3
         , Ui.style "color" dsInk3
         ]
-        [ iconBox 18 (Ui.phosphorBookOpen "")
+        [ iconBox 22 (Ui.phosphorBookOpen "")
         , Html.span
             [ Ui.style "font-family" theme.fontFamily
-            , Ui.style "font-size" "14px"
+            , Ui.style "font-size" "24px"
             , Ui.style "font-weight" "600"
-            , Ui.style "color" dsInk2
+            , Ui.style "color" dsInk
             ]
             [ Html.text "Reference" ]
         ]
@@ -1656,17 +1659,20 @@ sectionLabel theme isFirst label =
             ]
 
     else
+        -- A content heading inside the Reference section. One step below the
+        -- Reference H2 (24 / 600) on the type scale — H4 (16 / 600) — so it
+        -- reads as a subsection of Reference rather than competing with it.
         Html.div
             [ Ui.style "font-family" theme.fontFamily
-            , Ui.style "font-size" "18px"
-            , Ui.style "font-weight" "700"
+            , Ui.style "font-size" "16px"
+            , Ui.style "font-weight" "600"
             , Ui.style "color" dsInk
             , Ui.style "margin-top"
                 (if isFirst then
                     "20px"
 
                  else
-                    "44px"
+                    "32px"
                 )
             ]
             [ Html.text label ]

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -1248,11 +1248,26 @@ viewContent model =
     in
     Html.div
         [ Ui.style "max-width" "1080px"
-        , Ui.style "padding" "40px 40px 96px 40px"
+        , Ui.style "padding" "40px 40px 0 40px"
         , Ui.style "display" "flex"
         , Ui.style "flex-direction" "column"
         ]
-        (viewHeading model :: viewBody model frames)
+        (viewHeading model :: viewBody model frames ++ [ bottomSpacer ])
+
+
+{-| A real element (not just `padding-bottom`, which can read as no visible gap
+at the end of a flex scroll-content) guaranteeing ≥80px of empty breathing room
+after the final page content when scrolled to the bottom. It lives in the
+scrolling content column, so it does not touch the Inspector's own scroll area.
+-}
+bottomSpacer : Html (Msg t e)
+bottomSpacer =
+    Html.div
+        [ Ui.style "flex-shrink" "0"
+        , Ui.style "min-height" "80px"
+        , Ui.style "width" "100%"
+        ]
+        []
 
 
 {-| The page body. Configurable pages (those with a live component) get a single

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -81,7 +81,10 @@ type Msg t e
     = ComponentUpdate (Internal.Update t)
     | ViewPage String
     | UpdateSearch String
-    | ToggleFrameControls String
+    | ToggleInspector
+    | SelectInspector String
+    | ToggleGroup String
+    | ToggleTokenGroup String
 
 
 type alias Model t e =
@@ -91,7 +94,10 @@ type alias Model t e =
     , index : List Index
     , currentPage : String
     , search : String
-    , shownControls : Set String
+    , inspectorOpen : Bool
+    , activeInspector : Maybe String
+    , collapsedGroups : Set String
+    , collapsedTokens : Set String
     , theme : Theme
     }
 
@@ -357,7 +363,10 @@ init theme playgrounds url =
     , index = idx
     , currentPage = currentPage
     , search = ""
-    , shownControls = Set.empty
+    , inspectorOpen = True
+    , activeInspector = Nothing
+    , collapsedGroups = Set.empty
+    , collapsedTokens = Set.empty
     , theme = theme
     }
 
@@ -405,21 +414,33 @@ update msg model =
                     ( modelWithUpdates, [] )
 
         ViewPage pageId ->
-            ( { model | currentPage = pageId }, [] )
+            -- Reset the inspector target when navigating: the new page's first
+            -- inspectable frame becomes active (resolved lazily in the view).
+            ( { model | currentPage = pageId, activeInspector = Nothing }, [] )
 
         UpdateSearch newSearch ->
             ( { model | search = newSearch }, [] )
 
-        ToggleFrameControls frameId ->
-            let
-                shown =
-                    if Set.member frameId model.shownControls then
-                        Set.remove frameId model.shownControls
+        ToggleInspector ->
+            ( { model | inspectorOpen = not model.inspectorOpen }, [] )
 
-                    else
-                        Set.insert frameId model.shownControls
-            in
-            ( { model | shownControls = shown }, [] )
+        SelectInspector frameId ->
+            ( { model | activeInspector = Just frameId, inspectorOpen = True }, [] )
+
+        ToggleGroup groupId ->
+            ( { model | collapsedGroups = toggleMember groupId model.collapsedGroups }, [] )
+
+        ToggleTokenGroup groupName ->
+            ( { model | collapsedTokens = toggleMember groupName model.collapsedTokens }, [] )
+
+
+toggleMember : comparable -> Set comparable -> Set comparable
+toggleMember key set =
+    if Set.member key set then
+        Set.remove key set
+
+    else
+        Set.insert key set
 
 
 lookupCurrent : Model t e -> Ref -> Maybe (Type t)
@@ -489,6 +510,12 @@ fromUpdate =
 
 
 -- VIEW
+-- The playground shell: a left navigation sidebar, a top ribbon (breadcrumbs +
+-- Inspector trigger), the documentation column with a dedicated Playground card,
+-- and a full-height right-side Inspector that pushes the content in (Figma-style)
+-- rather than floating over it. Chrome is styled with the design-system token
+-- values (surface / line / ink / radius / elevation / spacing) so the shell is
+-- itself an example of correct design-system usage.
 
 
 view : Model t e -> Html (Msg t e)
@@ -496,17 +523,130 @@ view model =
     let
         theme =
             model.theme
+
+        inspectables =
+            pageInspectables model
+
+        showInspector =
+            model.inspectorOpen && not (List.isEmpty inspectables)
     in
-    Ui.hStack
-        (Ui.fullHeight
-            ++ [ Ui.style "background-color" theme.backgroundColor
-               , Ui.style "color" theme.textColor
-               , Ui.style "gap" "4px"
-               ]
-        )
-        [ viewSidebar model
-        , viewPage model
+    Html.div
+        [ Html.Attributes.class "cp-root"
+        , Ui.style "display" "flex"
+        , Ui.style "flex-direction" "row"
+        , Ui.style "height" "100vh"
+        , Ui.style "background-color" theme.backgroundColor
+        , Ui.style "color" theme.textColor
         ]
+        [ shellStylesheet
+        , viewSidebar model
+        , viewMainColumn model inspectables
+        , if showInspector then
+            viewInspectorPanel model inspectables
+
+          else
+            Html.text ""
+        ]
+
+
+{-| Interactive (Interactive / Presets) frames on the current page, paired with
+their ready-to-render control lists. These are the page's "live components"; the
+Inspector targets one at a time and shows tabs when there is more than one.
+-}
+type alias Inspectable t e =
+    { id : String
+    , name : String
+    , controls : List (Html (Msg t e))
+    }
+
+
+pageInspectables : Model t e -> List (Inspectable t e)
+pageInspectables model =
+    let
+        theme =
+            model.theme
+
+        lookup =
+            lookupCurrent model
+    in
+    Dict.get model.currentPage model.pages
+        |> Maybe.withDefault []
+        |> List.filterMap
+            (\frame ->
+                case frame of
+                    ProcessedInteractive meta _ internals ->
+                        Just
+                            { id = meta.id
+                            , name = meta.name
+                            , controls = List.map (Html.map ComponentUpdate) (internals.controls theme lookup)
+                            }
+
+                    ProcessedPresets meta _ internals ->
+                        Just
+                            { id = meta.id
+                            , name = meta.name
+                            , controls = List.map (Html.map ComponentUpdate) (internals.innerControls theme lookup)
+                            }
+
+                    _ ->
+                        Nothing
+            )
+
+
+{-| The Inspector's current target: the explicitly selected frame if it still
+exists on the page, otherwise the first inspectable frame.
+-}
+activeInspectable : Model t e -> List (Inspectable t e) -> Maybe (Inspectable t e)
+activeInspectable model inspectables =
+    case model.activeInspector of
+        Just id ->
+            case List.filter (\i -> i.id == id) inspectables of
+                first :: _ ->
+                    Just first
+
+                [] ->
+                    List.head inspectables
+
+        Nothing ->
+            List.head inspectables
+
+
+
+-- SHELL STYLESHEET
+-- Hover / focus / active states, the open-Inspector transition, and the
+-- narrow-viewport overlay behaviour. Layout properties that the media query
+-- must override (the Inspector's position) live here in classes rather than
+-- inline, so the breakpoint can win.
+
+
+shellStylesheet : Html msg
+shellStylesheet =
+    Html.node "style"
+        []
+        [ Html.text <|
+            String.join "\n"
+                [ ".cp-root, .cp-root *{box-sizing:border-box;}"
+                , ".cp-nav-row{transition:background-color .12s ease,color .12s ease;}"
+                , ".cp-nav-row:hover{background:" ++ dsSurfaceAlt ++ ";}"
+                , ".cp-nav-row:focus-visible{outline:2px solid " ++ dsBrandBlue ++ ";outline-offset:-2px;}"
+                , ".cp-nav-row.is-active{background:" ++ dsBrandBlue50 ++ ";}"
+                , ".cp-nav-row.is-active:hover{background:" ++ dsBrandBlue50 ++ ";}"
+                , ".cp-icon-btn{transition:background-color .12s ease,color .12s ease;}"
+                , ".cp-icon-btn:hover{background:" ++ dsSurfaceAlt ++ ";color:" ++ dsInk ++ ";}"
+                , ".cp-trigger{transition:background-color .12s ease,box-shadow .12s ease,border-color .12s ease;}"
+                , ".cp-trigger:hover{background:" ++ dsSurfaceAlt ++ ";}"
+                , ".cp-search{transition:border-color .12s ease,box-shadow .12s ease;}"
+                , ".cp-search:focus-within{border-color:" ++ dsBrandBlue ++ ";box-shadow:0 0 0 3px " ++ dsBrandBlue50 ++ ";}"
+                , ".cp-inspector{width:380px;flex-shrink:0;height:100vh;border-left:1px solid " ++ dsLine ++ ";background:" ++ dsSurface ++ ";display:flex;flex-direction:column;animation:cp-slide-in .18s ease;}"
+                , ".cp-inspector-body{flex:1;min-height:0;overflow-y:auto;}"
+                , "@keyframes cp-slide-in{from{transform:translateX(28px);opacity:.3;}to{transform:none;opacity:1;}}"
+                , "@media (max-width:1080px){.cp-inspector{position:fixed;top:0;right:0;bottom:0;height:auto;z-index:1000;box-shadow:" ++ dsShadow4 ++ ";}}"
+                ]
+        ]
+
+
+
+-- SIDEBAR
 
 
 viewSidebar : Model t e -> Html (Msg t e)
@@ -515,15 +655,12 @@ viewSidebar model =
         theme =
             model.theme
 
-        divider =
-            Ui.style "border-bottom" ("1px solid " ++ theme.dividerColor)
-
         footerBand =
             case theme.sidebarFooter of
                 Just content ->
                     [ Html.div
-                        [ Ui.style "padding" "16px 24px"
-                        , Ui.style "border-top" ("1px solid " ++ theme.dividerColor)
+                        [ Ui.style "padding" "16px 20px"
+                        , Ui.style "border-top" ("1px solid " ++ dsLine2)
                         ]
                         [ Html.map never content ]
                     ]
@@ -532,27 +669,29 @@ viewSidebar model =
                     []
     in
     Ui.vStack
-        [ Ui.style "width" "306px"
+        [ Ui.style "width" "300px"
         , Ui.style "flex-shrink" "0"
-        , Ui.style "max-height" "100%"
-        , Ui.style "border-right" ("1px solid " ++ theme.dividerColor)
+        , Ui.style "height" "100vh"
+        , Ui.style "background" dsSurface
+        , Ui.style "border-right" ("1px solid " ++ dsLine)
         ]
         (List.concat
             [ [ Html.div
                     (Ui.headingStyles theme
-                        ++ [ Ui.style "padding" "48px 16px 96px 24px"
+                        ++ [ Ui.style "padding" "28px 20px 20px 20px"
                            , Ui.style "white-space" "nowrap"
-                           , divider
+                           , Ui.style "border-bottom" ("1px solid " ++ dsLine2)
                            ]
                     )
                     [ Html.map never theme.sidebarHeader ]
               , viewSearchBand model
-              , Ui.vStack
+              , Html.div
                     [ Ui.style "flex-grow" "1"
+                    , Ui.style "min-height" "0"
                     , Ui.style "overflow-y" "auto"
-                    , Ui.style "padding" "16px 0"
+                    , Ui.style "padding" "8px 12px 24px 12px"
                     ]
-                    (List.map (viewIndex model) (orderChildren model.index))
+                    (viewNavList model)
               ]
             , footerBand
             ]
@@ -565,162 +704,215 @@ viewSearchBand model =
         theme =
             model.theme
     in
-    Html.div
-        [ Ui.style "display" "flex"
-        , Ui.style "align-items" "center"
-        , Ui.style "gap" "8px"
-        , Ui.style "padding" "16px 24px"
-        , Ui.style "border-bottom" ("1px solid " ++ theme.dividerColor)
-        , Ui.style "color" theme.mutedTextColor
-        ]
-        [ Html.div
-            [ Ui.style "width" "20px"
-            , Ui.style "height" "20px"
-            , Ui.style "flex-shrink" "0"
-            , Ui.style "display" "inline-flex"
+    Html.div [ Ui.style "padding" "12px 16px" ]
+        [ Html.label
+            [ Html.Attributes.class "cp-search"
+            , Ui.style "display" "flex"
+            , Ui.style "align-items" "center"
+            , Ui.style "gap" dsSpace2
+            , Ui.style "height" "38px"
+            , Ui.style "padding" "0 12px"
+            , Ui.style "background" dsSurfaceAlt
+            , Ui.style "border" ("1px solid " ++ dsLine)
+            , Ui.style "border-radius" dsRadiusMd
+            , Ui.style "color" dsInk4
             ]
-            [ Ui.lucideSearch "" ]
-        , Html.input
-            [ Html.Attributes.placeholder "Search"
-            , Html.Attributes.value model.search
-            , Html.Events.onInput UpdateSearch
-            , Html.Attributes.id "playground-search"
-            , Ui.style "border" "none"
-            , Ui.style "outline" "none"
-            , Ui.style "padding" "0"
-            , Ui.style "flex-grow" "1"
-            , Ui.style "background-color" "transparent"
-            , Ui.style "font-family" theme.fontFamily
-            , Ui.style "font-size" theme.bodyFontSize
-            , Ui.style "color" theme.textColor
-            , Ui.disableAutocomplete
+            [ iconBox 16 (Ui.lucideSearch "")
+            , Html.input
+                [ Html.Attributes.placeholder "Search components…"
+                , Html.Attributes.value model.search
+                , Html.Events.onInput UpdateSearch
+                , Html.Attributes.id "playground-search"
+                , Ui.style "border" "none"
+                , Ui.style "outline" "none"
+                , Ui.style "padding" "0"
+                , Ui.style "flex-grow" "1"
+                , Ui.style "min-width" "0"
+                , Ui.style "background-color" "transparent"
+                , Ui.style "font-family" theme.fontFamily
+                , Ui.style "font-size" "14px"
+                , Ui.style "color" dsInk
+                , Ui.disableAutocomplete
+                ]
+                []
             ]
-            []
         ]
 
 
-viewPage : Model t e -> Html (Msg t e)
-viewPage model =
+viewNavList : Model t e -> List (Html (Msg t e))
+viewNavList model =
+    orderChildren model.index
+        |> List.filter (indexHasMatch model.search)
+        |> List.map (viewNavNode model 0)
+
+
+viewNavNode : Model t e -> Int -> Index -> Html (Msg t e)
+viewNavNode model depth (Index item) =
+    if List.isEmpty item.children then
+        viewPageLink model depth { id = item.id, name = item.name }
+
+    else
+        let
+            filteredChildren =
+                item.children
+                    |> List.filter (indexHasMatch model.search)
+                    |> orderChildren
+
+            -- A search with matches force-opens its groups so results are visible.
+            isOpen =
+                not (Set.member item.id model.collapsedGroups) || model.search /= ""
+
+            children =
+                if isOpen then
+                    List.map (viewNavNode model (depth + 1)) filteredChildren
+
+                else
+                    []
+        in
+        Ui.vStack [] (viewGroupRow model depth item isOpen :: children)
+
+
+viewGroupRow : Model t e -> Int -> { id : String, name : String, children : List Index } -> Bool -> Html (Msg t e)
+viewGroupRow model depth item isOpen =
     let
         theme =
             model.theme
 
-        frames =
-            Dict.get model.currentPage model.pages
-                |> Maybe.withDefault []
+        chevron =
+            iconBox 14
+                (if isOpen then
+                    Ui.lucideChevronDown ""
 
-        pageName =
-            lookupPageName model.currentPage model.index
-                |> Maybe.withDefault ""
+                 else
+                    Ui.lucideChevronRight ""
+                )
     in
-    Ui.vStack
-        [ Ui.style "flex-grow" "1"
-        , Ui.style "max-height" "100%"
-        , Ui.style "overflow-y" "auto"
-        , Ui.style "border-left" ("1px solid " ++ theme.dividerColor)
-        ]
-        (Html.div
-            (Ui.headingStyles theme
-                ++ [ Ui.style "padding" "48px 20px 8px 20px"
-                   , Ui.style "border-bottom" ("1px solid " ++ theme.dividerColor)
-                   ]
-            )
-            [ Html.text pageName ]
-            :: viewFramesIndexed model frames
-        )
-
-
-{-| Render the page's frames, assigning each inspectable (interactive / presets)
-frame a sequential index so their viewport-pinned inspectors stack instead of
-overlapping. Non-inspectable frames don't advance the counter.
--}
-viewFramesIndexed : Model t e -> List (ProcessedFrame e t) -> List (Html (Msg t e))
-viewFramesIndexed model frames =
-    frames
-        |> List.foldl
-            (\frame ( idx, acc ) ->
-                if isInspectableFrame frame then
-                    ( idx + 1, viewFrame model idx frame :: acc )
-
-                else
-                    ( idx, viewFrame model idx frame :: acc )
-            )
-            ( 0, [] )
-        |> Tuple.second
-        |> List.reverse
-
-
-isInspectableFrame : ProcessedFrame e t -> Bool
-isInspectableFrame frame =
-    case frame of
-        ProcessedInteractive _ _ _ ->
-            True
-
-        ProcessedPresets _ _ _ ->
-            True
-
-        ProcessedStatic _ ->
-            False
-
-        ProcessedGallery _ ->
-            False
-
-        ProcessedSubheading _ ->
-            False
-
-
-lookupPageName : String -> List Index -> Maybe String
-lookupPageName id =
-    List.foldl
-        (\(Index item) acc ->
-            case acc of
-                Just _ ->
-                    acc
-
-                Nothing ->
-                    if item.id == id && List.isEmpty item.children then
-                        Just item.name
-
-                    else
-                        lookupPageName id item.children
-        )
-        Nothing
-
-
-viewIndex : Model t e -> Index -> Html (Msg t e)
-viewIndex model (Index item) =
-    if List.isEmpty item.children then
-        -- Page (leaf node)
-        if String.toLower item.name |> String.contains (String.toLower model.search) then
-            viewPageLink model { id = item.id, name = item.name }
-
-        else
-            Html.text ""
+    if depth == 0 then
+        -- Top-level section header — an uppercase, collapsible band.
+        Ui.button theme
+            [ Html.Attributes.class "cp-nav-row"
+            , Ui.style "display" "flex"
+            , Ui.style "align-items" "center"
+            , Ui.style "justify-content" "space-between"
+            , Ui.style "width" "100%"
+            , Ui.style "height" "32px"
+            , Ui.style "margin-top" "10px"
+            , Ui.style "padding" "0 8px"
+            , Ui.style "border-radius" dsRadiusMd
+            , Ui.style "font-family" theme.fontFamily
+            , Ui.style "font-size" "11px"
+            , Ui.style "font-weight" "700"
+            , Ui.style "letter-spacing" "0.06em"
+            , Ui.style "text-transform" "uppercase"
+            , Ui.style "color" dsInk4
+            , Ui.onClick (ToggleGroup item.id)
+            ]
+            [ Html.span [] [ Html.text item.name ]
+            , Html.span [ Ui.style "color" dsInk4 ] [ chevron ]
+            ]
 
     else
-        -- Group (has children)
-        let
-            filteredChildren =
-                List.filter (indexHasMatch model.search) item.children
-                    |> orderChildren
-        in
-        if List.isEmpty filteredChildren then
-            Html.text ""
+        -- Nested, expandable category (e.g. Button).
+        Ui.button theme
+            [ Html.Attributes.class "cp-nav-row"
+            , Ui.style "display" "flex"
+            , Ui.style "align-items" "center"
+            , Ui.style "gap" "6px"
+            , Ui.style "width" "100%"
+            , Ui.style "height" "34px"
+            , Ui.style "padding-left" (navIndent depth)
+            , Ui.style "padding-right" "10px"
+            , Ui.style "border-radius" dsRadiusMd
+            , Ui.style "border-left" "2px solid transparent"
+            , Ui.style "font-family" theme.fontFamily
+            , Ui.style "font-size" "14px"
+            , Ui.style "font-weight" "600"
+            , Ui.style "color" dsInk2
+            , Ui.onClick (ToggleGroup item.id)
+            ]
+            [ Html.span [ Ui.style "color" dsInk4 ] [ chevron ]
+            , Html.span [] [ Html.text item.name ]
+            ]
 
-        else
-            Ui.vStack []
-                [ Html.div
-                    [ Ui.style "padding" "0 24px"
-                    , Ui.style "height" "32px"
-                    , Ui.style "display" "flex"
-                    , Ui.style "align-items" "center"
-                    , Ui.style "font-family" model.theme.fontFamily
-                    , Ui.style "font-size" model.theme.subHeadingFontSize
-                    , Ui.style "color" model.theme.mutedTextColor
-                    ]
-                    [ Html.text item.name ]
-                , Ui.vStack [] (List.map (viewIndex model) filteredChildren)
+
+viewPageLink : Model t e -> Int -> { id : String, name : String } -> Html (Msg t e)
+viewPageLink model depth meta =
+    let
+        theme =
+            model.theme
+
+        isActive =
+            meta.id == model.currentPage
+    in
+    Ui.button theme
+        [ Html.Attributes.class
+            ("cp-nav-row"
+                ++ (if isActive then
+                        " is-active"
+
+                    else
+                        ""
+                   )
+            )
+        , Ui.style "display" "flex"
+        , Ui.style "align-items" "center"
+        , Ui.style "justify-content" "space-between"
+        , Ui.style "width" "100%"
+        , Ui.style "height" "32px"
+        , Ui.style "padding-left" (navIndent (depth + 1))
+        , Ui.style "padding-right" "10px"
+        , Ui.style "border-radius" dsRadiusMd
+        , Ui.style "border-left"
+            ("2px solid "
+                ++ (if isActive then
+                        dsBrandBlue
+
+                    else
+                        "transparent"
+                   )
+            )
+        , Ui.style "font-family" theme.fontFamily
+        , Ui.style "font-size" "14px"
+        , Ui.style "font-weight"
+            (if isActive then
+                "600"
+
+             else
+                "400"
+            )
+        , Ui.style "color"
+            (if isActive then
+                dsInk
+
+             else
+                dsInk3
+            )
+        , Ui.onClick (ViewPage meta.id)
+        ]
+        [ Html.span
+            [ Ui.style "overflow" "hidden"
+            , Ui.style "text-overflow" "ellipsis"
+            , Ui.style "white-space" "nowrap"
+            ]
+            [ Html.text meta.name ]
+        , if isActive then
+            Html.span
+                [ Ui.style "width" "6px"
+                , Ui.style "height" "6px"
+                , Ui.style "flex-shrink" "0"
+                , Ui.style "border-radius" "50%"
+                , Ui.style "background" dsBrandBlue
                 ]
+                []
+
+          else
+            Html.text ""
+        ]
+
+
+navIndent : Int -> String
+navIndent depth =
+    String.fromInt (8 + depth * 14) ++ "px"
 
 
 {-| Within a parent: leaf pages first (sorted alphabetically by name),
@@ -744,212 +936,411 @@ indexHasMatch search (Index item) =
         List.any (indexHasMatch search) item.children
 
 
-viewPageLink : Model t e -> { id : String, name : String } -> Html (Msg t e)
-viewPageLink model meta =
-    let
-        isActive =
-            meta.id == model.currentPage
 
+-- MAIN COLUMN
+
+
+viewMainColumn : Model t e -> List (Inspectable t e) -> Html (Msg t e)
+viewMainColumn model inspectables =
+    Ui.vStack
+        [ Ui.style "flex-grow" "1"
+        , Ui.style "min-width" "0"
+        , Ui.style "height" "100vh"
+        ]
+        [ viewTopRibbon model inspectables
+        , Html.div
+            [ Ui.style "flex-grow" "1"
+            , Ui.style "min-height" "0"
+            , Ui.style "overflow-y" "auto"
+            ]
+            [ viewContent model ]
+        ]
+
+
+viewTopRibbon : Model t e -> List (Inspectable t e) -> Html (Msg t e)
+viewTopRibbon model inspectables =
+    Html.div
+        [ Ui.style "display" "flex"
+        , Ui.style "align-items" "center"
+        , Ui.style "justify-content" "space-between"
+        , Ui.style "flex-shrink" "0"
+        , Ui.style "gap" dsSpace4
+        , Ui.style "height" "56px"
+        , Ui.style "padding" "0 24px"
+        , Ui.style "background" dsSurface
+        , Ui.style "border-bottom" ("1px solid " ++ dsLine)
+        , Ui.style "box-shadow" dsShadow1
+        ]
+        [ viewBreadcrumbs model
+        , if List.isEmpty inspectables then
+            Html.text ""
+
+          else
+            inspectorTrigger model
+        ]
+
+
+viewBreadcrumbs : Model t e -> Html (Msg t e)
+viewBreadcrumbs model =
+    let
         theme =
             model.theme
+
+        path =
+            pathTo model.currentPage model.index
+                |> Maybe.withDefault []
+
+        lastIndex =
+            List.length path - 1
+
+        separator =
+            Html.span
+                [ Ui.style "color" dsInk4
+                , Ui.style "font-size" "13px"
+                ]
+                [ Html.text "›" ]
+
+        crumb i meta =
+            let
+                isLast =
+                    i == lastIndex
+            in
+            Html.span
+                [ Ui.style "font-family" theme.fontFamily
+                , Ui.style "font-size" "13px"
+                , Ui.style "font-weight"
+                    (if isLast then
+                        "600"
+
+                     else
+                        "400"
+                    )
+                , Ui.style "color"
+                    (if isLast then
+                        dsInk
+
+                     else
+                        dsInk3
+                    )
+                , Ui.style "white-space" "nowrap"
+                ]
+                [ Html.text meta.name ]
     in
-    Ui.button theme
-        [ Ui.style "text-align" "left"
-        , Ui.style "padding" "0 24px 0 36px"
-        , Ui.style "height" "32px"
-        , Ui.style "width" "100%"
-        , Ui.style "font-family" theme.fontFamily
-        , Ui.style "font-size" theme.bodyFontSize
-        , Ui.style "color"
-            (if isActive then
-                theme.textColor
-
-             else
-                theme.mutedTextColor
-            )
-        , Ui.style "font-weight" theme.bodyFontWeight
-        , Ui.style "border-right"
-            (if isActive then
-                "2px solid " ++ theme.textColor
-
-             else
-                "2px solid transparent"
-            )
-        , Ui.onClick (ViewPage meta.id)
+    Html.div
+        [ Ui.style "display" "flex"
+        , Ui.style "align-items" "center"
+        , Ui.style "gap" dsSpace2
+        , Ui.style "min-width" "0"
+        , Ui.style "overflow" "hidden"
         ]
-        [ Html.text meta.name ]
+        (Html.span [ Ui.style "color" dsInk4 ] [ iconBox 16 (Ui.lucideHome "") ]
+            :: List.concat
+                (List.indexedMap
+                    (\i meta -> [ separator, crumb i meta ])
+                    path
+                )
+        )
 
 
-viewFrame : Model t e -> Int -> ProcessedFrame e t -> Html (Msg t e)
-viewFrame model inspectorIndex frame =
+pathTo : String -> List Index -> Maybe (List { id : String, name : String })
+pathTo target indices =
+    let
+        go (Index item) =
+            if List.isEmpty item.children then
+                if item.id == target then
+                    Just [ { id = item.id, name = item.name } ]
+
+                else
+                    Nothing
+
+            else
+                case List.filterMap go item.children of
+                    found :: _ ->
+                        Just ({ id = item.id, name = item.name } :: found)
+
+                    [] ->
+                        Nothing
+    in
+    case List.filterMap go indices of
+        found :: _ ->
+            Just found
+
+        [] ->
+            Nothing
+
+
+
+-- CONTENT COLUMN
+
+
+viewContent : Model t e -> Html (Msg t e)
+viewContent model =
+    let
+        frames =
+            Dict.get model.currentPage model.pages
+                |> Maybe.withDefault []
+    in
+    Html.div
+        [ Ui.style "max-width" "1080px"
+        , Ui.style "padding" "40px 40px 96px 40px"
+        , Ui.style "display" "flex"
+        , Ui.style "flex-direction" "column"
+        ]
+        (viewHeading model :: viewFramesList model frames)
+
+
+viewHeading : Model t e -> Html (Msg t e)
+viewHeading model =
+    let
+        theme =
+            model.theme
+
+        pageName =
+            lookupPageName model.currentPage model.index
+                |> Maybe.withDefault ""
+
+        crumbs =
+            pathTo model.currentPage model.index
+                |> Maybe.withDefault []
+
+        subtitle =
+            crumbs
+                |> List.reverse
+                |> List.drop 1
+                |> List.reverse
+                |> List.map .name
+                |> String.join " · "
+    in
+    Html.div
+        [ Ui.style "display" "flex"
+        , Ui.style "align-items" "center"
+        , Ui.style "gap" dsSpace4
+        , Ui.style "margin-bottom" "8px"
+        ]
+        [ Html.div
+            [ Ui.style "width" "44px"
+            , Ui.style "height" "44px"
+            , Ui.style "flex-shrink" "0"
+            , Ui.style "display" "inline-flex"
+            , Ui.style "align-items" "center"
+            , Ui.style "justify-content" "center"
+            , Ui.style "background" dsBrandBlue50
+            , Ui.style "border-radius" dsRadiusLg
+            , Ui.style "color" dsBrandBlue
+            ]
+            [ iconBox 22 (Ui.lucideBox "") ]
+        , Ui.vStack [ Ui.style "gap" "2px", Ui.style "min-width" "0" ]
+            (List.concat
+                [ if String.isEmpty subtitle then
+                    []
+
+                  else
+                    [ Html.div
+                        [ Ui.style "font-family" theme.fontFamily
+                        , Ui.style "font-size" "11px"
+                        , Ui.style "font-weight" "600"
+                        , Ui.style "letter-spacing" "0.06em"
+                        , Ui.style "text-transform" "uppercase"
+                        , Ui.style "color" dsInk4
+                        ]
+                        [ Html.text subtitle ]
+                    ]
+                , [ Html.div
+                        [ Ui.style "font-family" theme.fontFamily
+                        , Ui.style "font-size" "28px"
+                        , Ui.style "font-weight" "700"
+                        , Ui.style "color" dsInk
+                        ]
+                        [ Html.text pageName ]
+                  ]
+                ]
+            )
+        ]
+
+
+viewFramesList : Model t e -> List (ProcessedFrame e t) -> List (Html (Msg t e))
+viewFramesList model frames =
+    List.indexedMap (\i frame -> viewFrame model (i == 0) frame) frames
+
+
+viewFrame : Model t e -> Bool -> ProcessedFrame e t -> Html (Msg t e)
+viewFrame model isFirst frame =
     case frame of
-        ProcessedInteractive meta wrapper internals ->
-            viewInteractiveFrame model inspectorIndex meta wrapper internals
+        ProcessedInteractive _ wrapper internals ->
+            playgroundCard Nothing (renderComponentView model internals wrapper identity)
 
-        ProcessedPresets meta wrapper internals ->
-            viewPresetsFrame model inspectorIndex meta wrapper internals
+        ProcessedPresets _ wrapper internals ->
+            let
+                ( tabBar, presetWrap ) =
+                    presetBits model internals
+            in
+            playgroundCard tabBar (renderComponentView model internals wrapper presetWrap)
 
         ProcessedStatic html ->
             Html.div
-                [ Ui.style "padding" "8px 20px"
-                , Ui.style "border-bottom" ("1px solid " ++ model.theme.dividerColor)
+                [ Ui.style "margin-top"
+                    (if isFirst then
+                        "0"
+
+                     else
+                        dsSpace2
+                    )
+                , Ui.style "color" dsInk3
+                , Ui.style "font-size" "14px"
                 ]
                 [ Html.map ComponentUpdate html ]
 
         ProcessedGallery html ->
-            Html.div
-                [ Ui.style "padding" "8px 20px"
-                , Ui.style "border-bottom" ("1px solid " ++ model.theme.dividerColor)
-                ]
-                [ Html.map ComponentUpdate html ]
+            specimenBlock (Html.map ComponentUpdate html)
 
         ProcessedSubheading label ->
-            Html.div
-                (Ui.subHeadingStyles model.theme
-                    ++ [ Ui.style "padding" "32px 20px 8px 20px"
-                       , Ui.style "border-bottom" ("1px solid " ++ model.theme.dividerColor)
-                       ]
-                )
-                [ Html.text label ]
+            sectionLabel model.theme isFirst label
 
 
-viewInteractiveFrame : Model t e -> Int -> { id : String, name : String } -> (Html (Update t) -> Html (Update t)) -> ComponentE e t -> Html (Msg t e)
-viewInteractiveFrame model inspectorIndex meta wrapper internals =
-    viewFramedComponent
-        { model = model
-        , frameId = meta.id
-        , frameName = meta.name
-        , inspectorIndex = inspectorIndex
-        , wrapper = wrapper
-        , internals = internals
-        , viewPrefix = Nothing
-        , viewWrap = identity
-        , controlsList = internals.controls
-        }
+renderComponentView : Model t e -> ComponentE e t -> (Html (Update t) -> Html (Update t)) -> (Html (Update t) -> Html (Update t)) -> Html (Msg t e)
+renderComponentView model internals wrapper viewWrap =
+    internals.render (lookupCurrent model)
+        |> Tuple.first
+        |> viewWrap
+        |> wrapper
+        |> Html.map ComponentUpdate
 
 
-viewPresetsFrame : Model t e -> Int -> { id : String, name : String } -> (Html (Update t) -> Html (Update t)) -> ComponentE e t -> Html (Msg t e)
-viewPresetsFrame model inspectorIndex meta wrapper internals =
-    let
-        ( tabBar, activePresetWrap ) =
-            case internals.presets of
-                Just info ->
-                    let
-                        lookup =
-                            lookupCurrent model
-                    in
-                    ( Just (viewPresetTabBar model.theme info lookup)
-                    , info.current lookup
-                        |> Maybe.map info.wrapAt
-                        |> Maybe.withDefault identity
-                    )
+presetBits : Model t e -> ComponentE e t -> ( Maybe (Html (Msg t e)), Html (Update t) -> Html (Update t) )
+presetBits model internals =
+    case internals.presets of
+        Just info ->
+            let
+                lookup =
+                    lookupCurrent model
+            in
+            ( Just (viewPresetTabBar model.theme info lookup)
+            , info.current lookup
+                |> Maybe.map info.wrapAt
+                |> Maybe.withDefault identity
+            )
+
+        Nothing ->
+            ( Nothing, identity )
+
+
+{-| The Playground live-component container: a polished surface (line border,
+radius, soft elevation) holding a single live component, left aligned. The
+component's variant / size / state are driven from the Inspector.
+-}
+playgroundCard : Maybe (Html (Msg t e)) -> Html (Msg t e) -> Html (Msg t e)
+playgroundCard maybeTabBar inner =
+    Html.div
+        [ Ui.style "margin-top" "16px"
+        , Ui.style "background" dsSurface
+        , Ui.style "border" ("1px solid " ++ dsLine)
+        , Ui.style "border-radius" dsRadiusLg
+        , Ui.style "box-shadow" dsShadow2
+        , Ui.style "overflow" "hidden"
+        ]
+        (List.concat
+            [ case maybeTabBar of
+                Just tabBar ->
+                    [ tabBar ]
 
                 Nothing ->
-                    ( Nothing, identity )
-    in
-    viewFramedComponent
-        { model = model
-        , frameId = meta.id
-        , frameName = meta.name
-        , inspectorIndex = inspectorIndex
-        , wrapper = wrapper
-        , internals = internals
-        , viewPrefix = tabBar
-        , viewWrap = activePresetWrap
-        , controlsList = internals.innerControls
-        }
+                    []
+            , [ Html.div
+                    [ Ui.style "display" "flex"
+                    , Ui.style "flex-direction" "column"
+                    , Ui.style "align-items" "flex-start"
+                    , Ui.style "padding" "28px"
+                    , Ui.style "min-width" "0"
+                    ]
+                    [ inner ]
+              ]
+            ]
+        )
 
 
-viewFramedComponent :
-    { model : Model t e
-    , frameId : String
-    , frameName : String
-    , inspectorIndex : Int
-    , wrapper : Html (Update t) -> Html (Update t)
-    , internals : ComponentE e t
-    , viewPrefix : Maybe (Html (Msg t e))
-    , viewWrap : Html (Update t) -> Html (Update t)
-    , controlsList : Theme -> (Ref -> Maybe (Type t)) -> List (Html (Update t))
-    }
-    -> Html (Msg t e)
-viewFramedComponent cfg =
-    let
-        model =
-            cfg.model
-
-        theme =
-            model.theme
-
-        lookup =
-            lookupCurrent model
-
-        controlsShown =
-            Set.member cfg.frameId model.shownControls
-
-        renderedView =
-            cfg.internals.render lookup
-                |> Tuple.first
-                |> cfg.viewWrap
-                |> cfg.wrapper
-                |> Html.map ComponentUpdate
-
-        componentColumn =
-            Ui.vStack
-                [ Ui.style "min-width" "0" ]
-                (case cfg.viewPrefix of
-                    Just prefix ->
-                        [ prefix
-                        , Html.div
-                            [ Ui.style "padding" "8px 8px 8px 20px" ]
-                            [ renderedView ]
-                        ]
-
-                    Nothing ->
-                        [ Html.div
-                            [ Ui.style "padding" "8px 8px 8px 20px" ]
-                            [ renderedView ]
-                        ]
-                )
-
-        -- The inspector is pinned to the viewport (position: fixed) at the
-        -- top-right, so it stays put while the page scrolls and never pushes
-        -- the component down. When a page has several inspectors they stack
-        -- downward by inspectorIndex (44px slots) so triggers never overlap.
-        inspectorTop =
-            "calc(16px + " ++ String.fromInt (cfg.inspectorIndex * 44) ++ "px)"
-
-        inspector =
-            Html.div
-                [ Ui.style "position" "fixed"
-                , Ui.style "top" inspectorTop
-                , Ui.style "right" dsSpace4
-                , Ui.style "z-index" "1000"
-                ]
-                [ if controlsShown then
-                    inspectorPanel theme
-                        cfg.frameName
-                        cfg.frameId
-                        cfg.inspectorIndex
-                        (List.map (Html.map ComponentUpdate) (cfg.controlsList theme lookup))
-
-                  else
-                    inspectorTrigger theme cfg.frameName cfg.frameId
-                ]
-    in
+{-| A reference / specimen block (variant matrices, size charts). Uses the muted
+alt surface so it visually contrasts with the white Playground card above it.
+-}
+specimenBlock : Html (Msg t e) -> Html (Msg t e)
+specimenBlock html =
     Html.div
-        [ Ui.style "position" "relative"
-        , Ui.style "border-bottom" ("1px solid " ++ theme.dividerColor)
+        [ Ui.style "margin-top" "16px"
+        , Ui.style "background" dsSurfaceAlt
+        , Ui.style "border" ("1px solid " ++ dsLine2)
+        , Ui.style "border-radius" dsRadiusLg
+        , Ui.style "padding" "24px"
+        , Ui.style "overflow-x" "auto"
         ]
-        [ componentColumn
-        , inspector
-        ]
+        [ html ]
+
+
+sectionLabel : Theme -> Bool -> String -> Html (Msg t e)
+sectionLabel theme isFirst label =
+    if label == "Playground" then
+        Html.div
+            [ Ui.style "display" "flex"
+            , Ui.style "align-items" "center"
+            , Ui.style "gap" dsSpace2
+            , Ui.style "margin-top"
+                (if isFirst then
+                    "20px"
+
+                 else
+                    "40px"
+                )
+            , Ui.style "color" dsInk3
+            ]
+            [ iconBox 18 (Ui.lucideFerrisWheel "")
+            , Html.span
+                [ Ui.style "font-family" theme.fontFamily
+                , Ui.style "font-size" "14px"
+                , Ui.style "font-weight" "600"
+                , Ui.style "color" dsInk2
+                ]
+                [ Html.text label ]
+            ]
+
+    else
+        Html.div
+            [ Ui.style "font-family" theme.fontFamily
+            , Ui.style "font-size" "18px"
+            , Ui.style "font-weight" "700"
+            , Ui.style "color" dsInk
+            , Ui.style "margin-top"
+                (if isFirst then
+                    "20px"
+
+                 else
+                    "44px"
+                )
+            ]
+            [ Html.text label ]
+
+
+lookupPageName : String -> List Index -> Maybe String
+lookupPageName id =
+    List.foldl
+        (\(Index item) acc ->
+            case acc of
+                Just _ ->
+                    acc
+
+                Nothing ->
+                    if item.id == id && List.isEmpty item.children then
+                        Just item.name
+
+                    else
+                        lookupPageName id item.children
+        )
+        Nothing
 
 
 
 -- INSPECTOR
--- The playground's property panel. Styled with the design-system token values
--- (surface / line / ink / radius / elevation / spacing) so the inspector is
--- itself an example of correct design-system usage.
+-- A full-height, right-side push-in panel (Figma-style). The main content column
+-- resizes to make room rather than being overlaid. The header carries the title
+-- and a close button; component metadata leads the body, optional component tabs
+-- follow, then component settings, then the read-only design-token reference.
 
 
 dsSurface : String
@@ -975,6 +1366,11 @@ dsLine2 =
 dsInk : String
 dsInk =
     "#202326"
+
+
+dsInk2 : String
+dsInk2 =
+    "#3A4149"
 
 
 dsInk3 : String
@@ -1012,6 +1408,21 @@ dsSpace4 =
     "16px"
 
 
+dsRadiusMd : String
+dsRadiusMd =
+    "8px"
+
+
+dsRadiusLg : String
+dsRadiusLg =
+    "10px"
+
+
+dsShadow1 : String
+dsShadow1 =
+    "0 1px 2px rgba(16,24,40,0.05)"
+
+
 dsShadow2 : String
 dsShadow2 =
     "0 2px 4px rgba(16,24,40,0.06), 0 4px 8px rgba(16,24,40,0.04)"
@@ -1022,135 +1433,253 @@ dsShadow4 =
     "0 8px 16px rgba(16,24,40,0.08), 0 24px 48px rgba(16,24,40,0.12)"
 
 
-iconBox : Html msg -> Html msg
-iconBox icon =
+iconBox : Int -> Html msg -> Html msg
+iconBox size icon =
     Html.span
-        [ Ui.style "width" "16px"
-        , Ui.style "height" "16px"
+        [ Ui.style "width" (String.fromInt size ++ "px")
+        , Ui.style "height" (String.fromInt size ++ "px")
         , Ui.style "display" "inline-flex"
         , Ui.style "flex-shrink" "0"
         ]
         [ icon ]
 
 
-{-| Closed state — a discoverable, labelled "Inspector" trigger (design-system
-button: surface, line border, radius-md, shadow).
+{-| Closed state — a labelled, contained "Inspector" trigger in the top ribbon
+(design-system button: surface, line border, radius, shadow, side-panel icon).
+When the Inspector is open the trigger reads as pressed (brand-tinted).
 -}
-inspectorTrigger : Theme -> String -> String -> Html (Msg t e)
-inspectorTrigger theme frameName frameId =
-    Ui.button theme
-        [ Ui.style "display" "inline-flex"
+inspectorTrigger : Model t e -> Html (Msg t e)
+inspectorTrigger model =
+    let
+        open =
+            model.inspectorOpen
+    in
+    Ui.button model.theme
+        [ Html.Attributes.class "cp-trigger"
+        , Ui.style "display" "inline-flex"
         , Ui.style "align-items" "center"
         , Ui.style "gap" dsSpace2
-        , Ui.style "height" "32px"
+        , Ui.style "height" "34px"
         , Ui.style "padding" "0 12px"
-        , Ui.style "background" dsSurface
-        , Ui.style "border" ("1px solid " ++ dsLine)
-        , Ui.style "border-radius" "6px"
-        , Ui.style "box-shadow" dsShadow2
-        , Ui.style "color" dsInk
+        , Ui.style "flex-shrink" "0"
+        , Ui.style "background"
+            (if open then
+                dsBrandBlue50
+
+             else
+                dsSurface
+            )
+        , Ui.style "border"
+            ("1px solid "
+                ++ (if open then
+                        dsBrandBlue
+
+                    else
+                        dsLine
+                   )
+            )
+        , Ui.style "border-radius" dsRadiusMd
+        , Ui.style "box-shadow" dsShadow1
+        , Ui.style "color"
+            (if open then
+                dsBrandBlue
+
+             else
+                dsInk
+            )
         , Ui.style "font-size" "13px"
-        , Ui.style "font-weight" "500"
-        , Html.Attributes.title ("Inspect " ++ frameName)
-        , Ui.onClick (ToggleFrameControls frameId)
+        , Ui.style "font-weight" "600"
+        , Html.Attributes.title "Toggle Inspector"
+        , Ui.onClick ToggleInspector
         ]
-        [ iconBox (Ui.lucideSettings2 ""), Html.text "Inspector" ]
+        [ iconBox 16 (Ui.lucidePanelRight ""), Html.text "Inspector" ]
 
 
-{-| Open state — the floating property panel: a single design-system surface
-(radius-lg, shadow-4, line border) that grows with content up to the viewport
-and then scrolls internally, while the panel itself stays put.
--}
-inspectorPanel : Theme -> String -> String -> Int -> List (Html (Msg t e)) -> Html (Msg t e)
-inspectorPanel theme frameName frameId inspectorIndex controls =
+viewInspectorPanel : Model t e -> List (Inspectable t e) -> Html (Msg t e)
+viewInspectorPanel model inspectables =
+    let
+        theme =
+            model.theme
+
+        active =
+            activeInspectable model inspectables
+
+        controls =
+            active
+                |> Maybe.map .controls
+                |> Maybe.withDefault []
+    in
+    Html.div [ Html.Attributes.class "cp-inspector" ]
+        [ inspectorHeader theme
+        , Html.div [ Html.Attributes.class "cp-inspector-body" ]
+            (List.concat
+                [ [ inspectorMetadata theme active ]
+                , if List.length inspectables > 1 then
+                    [ inspectorTabs model active inspectables ]
+
+                  else
+                    []
+                , [ inspectorSection theme "Component Settings" Nothing controls
+                  , inspectorSection theme "Design Tokens" (Just "Read-only reference") [ tokenReference model ]
+                  ]
+                ]
+            )
+        ]
+
+
+inspectorHeader : Theme -> Html (Msg t e)
+inspectorHeader theme =
     Html.div
-        [ Ui.style "width" "334px"
-        , Ui.style "max-width" "calc(100vw - 32px)"
-        , Ui.style "max-height" ("calc(100vh - 32px - " ++ String.fromInt (inspectorIndex * 44) ++ "px)")
-        , Ui.style "overflow-y" "auto"
-        , Ui.style "background" dsSurface
-        , Ui.style "border" ("1px solid " ++ dsLine)
-        , Ui.style "border-radius" "8px"
-        , Ui.style "box-shadow" dsShadow4
-        , Ui.style "display" "flex"
-        , Ui.style "flex-direction" "column"
-        ]
-        [ inspectorHeader theme frameName frameId
-        , inspectorSection theme "Component Settings" Nothing controls
-        , inspectorSection theme "Design Tokens" (Just "Design-system token reference") [ tokenReference theme ]
-        , inspectorSection theme "Component Metadata" Nothing [ metadataRow theme "Component" frameName, metadataRow theme "Source" frameId ]
-        ]
-
-
-inspectorHeader : Theme -> String -> String -> Html (Msg t e)
-inspectorHeader theme frameName frameId =
-    Html.div
-        [ Ui.style "position" "sticky"
-        , Ui.style "top" "0"
-        , Ui.style "display" "flex"
+        [ Ui.style "display" "flex"
         , Ui.style "align-items" "center"
         , Ui.style "justify-content" "space-between"
-        , Ui.style "padding" (dsSpace3 ++ " " ++ dsSpace4)
-        , Ui.style "background" dsSurface
+        , Ui.style "flex-shrink" "0"
+        , Ui.style "padding" "16px 20px"
         , Ui.style "border-bottom" ("1px solid " ++ dsLine)
-        , Ui.style "z-index" "1"
         ]
-        [ Html.div
-            [ Ui.style "display" "flex"
-            , Ui.style "flex-direction" "column"
-            , Ui.style "gap" "1px"
-            , Ui.style "min-width" "0"
+        [ Html.span
+            [ Ui.style "font-family" theme.fontFamily
+            , Ui.style "font-size" "15px"
+            , Ui.style "font-weight" "700"
+            , Ui.style "color" dsInk
             ]
-            [ Html.span
-                [ Ui.style "font-family" theme.fontFamily
-                , Ui.style "font-size" "13px"
-                , Ui.style "font-weight" "600"
-                , Ui.style "color" dsInk
-                ]
-                [ Html.text "Inspector" ]
-            , Html.span
-                [ Ui.style "font-family" theme.fontFamily
-                , Ui.style "font-size" "11px"
-                , Ui.style "color" dsInk4
-                , Ui.style "overflow" "hidden"
-                , Ui.style "text-overflow" "ellipsis"
-                , Ui.style "white-space" "nowrap"
-                ]
-                [ Html.text frameName ]
-            ]
+            [ Html.text "Inspector" ]
         , Ui.button theme
-            [ Ui.style "width" "28px"
-            , Ui.style "height" "28px"
-            , Ui.style "display" "inline-flex"
-            , Ui.style "align-items" "center"
-            , Ui.style "justify-content" "center"
-            , Ui.style "background" dsBrandBlue50
-            , Ui.style "border-radius" "6px"
-            , Ui.style "color" dsBrandBlue
+            [ Html.Attributes.class "cp-icon-btn"
+            , Ui.style "width" "30px"
+            , Ui.style "height" "30px"
+            , Ui.style "border-radius" dsRadiusMd
+            , Ui.style "color" dsInk3
             , Html.Attributes.title "Close inspector"
-            , Ui.onClick (ToggleFrameControls frameId)
+            , Ui.onClick ToggleInspector
             ]
-            [ iconBox (Ui.lucideSettings2 "") ]
+            [ iconBox 18 (Ui.lucideX "") ]
         ]
+
+
+inspectorMetadata : Theme -> Maybe (Inspectable t e) -> Html (Msg t e)
+inspectorMetadata theme active =
+    case active of
+        Just a ->
+            Html.div
+                [ Ui.style "display" "flex"
+                , Ui.style "flex-direction" "column"
+                , Ui.style "gap" dsSpace2
+                , Ui.style "padding" "16px 20px"
+                , Ui.style "border-bottom" ("1px solid " ++ dsLine2)
+                ]
+                [ Html.div (eyebrowStyles theme) [ Html.text "Component" ]
+                , Html.div
+                    [ Ui.style "display" "flex"
+                    , Ui.style "align-items" "center"
+                    , Ui.style "gap" dsSpace2
+                    ]
+                    [ Html.span [ Ui.style "color" dsBrandBlue ] [ iconBox 16 (Ui.lucideBox "") ]
+                    , Html.span
+                        [ Ui.style "font-family" theme.fontFamily
+                        , Ui.style "font-size" "14px"
+                        , Ui.style "font-weight" "600"
+                        , Ui.style "color" dsInk
+                        ]
+                        [ Html.text a.name ]
+                    ]
+                , Html.span
+                    [ Ui.style "align-self" "flex-start"
+                    , Ui.style "font-family" "'Roboto Mono', monospace"
+                    , Ui.style "font-size" "11px"
+                    , Ui.style "color" dsInk3
+                    , Ui.style "background" dsSurfaceAlt
+                    , Ui.style "border" ("1px solid " ++ dsLine2)
+                    , Ui.style "border-radius" dsRadiusSm
+                    , Ui.style "padding" "2px 6px"
+                    ]
+                    [ Html.text a.id ]
+                ]
+
+        Nothing ->
+            Html.text ""
+
+
+inspectorTabs : Model t e -> Maybe (Inspectable t e) -> List (Inspectable t e) -> Html (Msg t e)
+inspectorTabs model active inspectables =
+    let
+        theme =
+            model.theme
+
+        activeId =
+            Maybe.map .id active
+
+        tab inspectable =
+            let
+                isActive =
+                    Just inspectable.id == activeId
+            in
+            Ui.button theme
+                [ Ui.style "padding" "10px 4px 8px"
+                , Ui.style "border-bottom"
+                    ("2px solid "
+                        ++ (if isActive then
+                                dsBrandBlue
+
+                            else
+                                "transparent"
+                           )
+                    )
+                , Ui.style "font-size" "13px"
+                , Ui.style "font-weight"
+                    (if isActive then
+                        "600"
+
+                     else
+                        "400"
+                    )
+                , Ui.style "color"
+                    (if isActive then
+                        dsInk
+
+                     else
+                        dsInk3
+                    )
+                , Ui.onClick (SelectInspector inspectable.id)
+                ]
+                [ Html.text inspectable.name ]
+    in
+    Html.div
+        [ Ui.style "display" "flex"
+        , Ui.style "flex-wrap" "wrap"
+        , Ui.style "gap" dsSpace3
+        , Ui.style "padding" "0 20px"
+        , Ui.style "border-bottom" ("1px solid " ++ dsLine2)
+        ]
+        (List.map tab inspectables)
+
+
+eyebrowStyles : Theme -> List (Html.Attribute msg)
+eyebrowStyles theme =
+    [ Ui.style "font-family" theme.fontFamily
+    , Ui.style "font-size" "10px"
+    , Ui.style "font-weight" "600"
+    , Ui.style "letter-spacing" "0.08em"
+    , Ui.style "text-transform" "uppercase"
+    , Ui.style "color" dsInk4
+    ]
+
+
+dsRadiusSm : String
+dsRadiusSm =
+    "4px"
 
 
 inspectorSection : Theme -> String -> Maybe String -> List (Html msg) -> Html msg
 inspectorSection theme title caption content =
     Html.div
-        [ Ui.style "padding" dsSpace4
+        [ Ui.style "padding" "16px 20px"
         , Ui.style "border-bottom" ("1px solid " ++ dsLine2)
         , Ui.style "display" "flex"
         , Ui.style "flex-direction" "column"
         , Ui.style "gap" dsSpace3
         ]
-        (Html.div
-            [ Ui.style "font-family" theme.fontFamily
-            , Ui.style "font-size" "10px"
-            , Ui.style "font-weight" "600"
-            , Ui.style "letter-spacing" "0.08em"
-            , Ui.style "text-transform" "uppercase"
-            , Ui.style "color" dsInk4
-            ]
+        (Html.div (eyebrowStyles theme)
             (Html.text title
                 :: (case caption of
                         Just c ->
@@ -1178,58 +1707,75 @@ inspectorSection theme title caption content =
         )
 
 
-metadataRow : Theme -> String -> String -> Html msg
-metadataRow theme name value =
-    Html.div
-        [ Ui.style "display" "flex"
-        , Ui.style "justify-content" "space-between"
-        , Ui.style "gap" dsSpace3
-        , Ui.style "font-family" theme.fontFamily
-        , Ui.style "font-size" "12px"
-        ]
-        [ Html.span [ Ui.style "color" dsInk3 ] [ Html.text name ]
-        , Html.span [ Ui.style "color" dsInk, Ui.style "font-weight" "500" ] [ Html.text value ]
-        ]
-
-
-{-| A read-only reference of the design-system token vocabulary, grouped by
-category. The framework treats components as opaque render functions, so this is
-the token vocabulary — not a per-component usage filter.
+{-| A read-only reference of the design-system token vocabulary, grouped into
+collapsible categories. The framework treats components as opaque render
+functions, so this is the token vocabulary — not a per-component usage filter.
 -}
-tokenReference : Theme -> Html msg
-tokenReference theme =
+tokenReference : Model t e -> Html (Msg t e)
+tokenReference model =
     Html.div
         [ Ui.style "display" "flex"
         , Ui.style "flex-direction" "column"
-        , Ui.style "gap" dsSpace3
+        , Ui.style "gap" dsSpace2
         ]
-        [ tokenGroup theme "Typography" [ ( "text-xs", "12px" ), ( "text-sm", "14px" ), ( "text-base", "16px" ), ( "text-lg", "18px" ) ]
-        , tokenGroup theme "Colour" [ ( "pw-surface", dsSurface ), ( "pw-surface-alt", dsSurfaceAlt ), ( "pw-ink", dsInk ), ( "pw-ink-3", dsInk3 ), ( "pw-line", dsLine ) ]
-        , tokenGroup theme "Radius" [ ( "rounded-sm", "4px" ), ( "rounded-md", "6px" ), ( "rounded-lg", "8px" ) ]
-        , tokenGroup theme "Elevation" [ ( "shadow-1", "" ), ( "shadow-2", "" ), ( "shadow-3", "" ), ( "shadow-4", "" ) ]
-        , tokenGroup theme "Spacing" [ ( "space-1", "4px" ), ( "space-2", "8px" ), ( "space-3", "12px" ), ( "space-4", "16px" ) ]
+        [ tokenGroup model "Typography" [ ( "text-xs", "12px" ), ( "text-sm", "14px" ), ( "text-base", "16px" ), ( "text-lg", "18px" ) ]
+        , tokenGroup model "Colour" [ ( "pw-surface", dsSurface ), ( "pw-surface-alt", dsSurfaceAlt ), ( "pw-ink", dsInk ), ( "pw-ink-3", dsInk3 ), ( "pw-line", dsLine ) ]
+        , tokenGroup model "Radius" [ ( "rounded-sm", dsRadiusSm ), ( "rounded-md", dsRadiusMd ), ( "rounded-lg", dsRadiusLg ) ]
+        , tokenGroup model "Elevation" [ ( "shadow-1", "" ), ( "shadow-2", "" ), ( "shadow-4", "" ) ]
+        , tokenGroup model "Spacing" [ ( "space-2", "8px" ), ( "space-3", "12px" ), ( "space-4", "16px" ) ]
+        , tokenGroup model "Motion" [ ( "ease-out", "150ms" ), ( "ease-spring", "200ms" ) ]
         ]
 
 
-tokenGroup : Theme -> String -> List ( String, String ) -> Html msg
-tokenGroup theme groupName rows =
+tokenGroup : Model t e -> String -> List ( String, String ) -> Html (Msg t e)
+tokenGroup model groupName rows =
+    let
+        theme =
+            model.theme
+
+        collapsed =
+            Set.member groupName model.collapsedTokens
+    in
     Html.div
         [ Ui.style "display" "flex"
         , Ui.style "flex-direction" "column"
         , Ui.style "gap" "4px"
         ]
-        (Html.div
-            [ Ui.style "font-family" theme.fontFamily
+        (Ui.button theme
+            [ Html.Attributes.class "cp-nav-row"
+            , Ui.style "display" "flex"
+            , Ui.style "align-items" "center"
+            , Ui.style "justify-content" "space-between"
+            , Ui.style "width" "100%"
+            , Ui.style "padding" "4px 6px"
+            , Ui.style "border-radius" dsRadiusSm
+            , Ui.style "font-family" theme.fontFamily
             , Ui.style "font-size" "11px"
             , Ui.style "font-weight" "600"
-            , Ui.style "color" dsInk3
+            , Ui.style "color" dsInk2
+            , Ui.onClick (ToggleTokenGroup groupName)
             ]
-            [ Html.text groupName ]
-            :: List.map (tokenRow theme) rows
+            [ Html.text groupName
+            , Html.span [ Ui.style "color" dsInk4 ]
+                [ iconBox 14
+                    (if collapsed then
+                        Ui.lucideChevronRight ""
+
+                     else
+                        Ui.lucideChevronDown ""
+                    )
+                ]
+            ]
+            :: (if collapsed then
+                    []
+
+                else
+                    List.map (tokenRow theme) rows
+               )
         )
 
 
-tokenRow : Theme -> ( String, String ) -> Html msg
+tokenRow : Theme -> ( String, String ) -> Html (Msg t e)
 tokenRow theme ( name, value ) =
     Html.div
         [ Ui.style "display" "flex"
@@ -1239,7 +1785,7 @@ tokenRow theme ( name, value ) =
         , Ui.style "padding" "3px 8px"
         , Ui.style "background" dsSurfaceAlt
         , Ui.style "border" ("1px solid " ++ dsLine2)
-        , Ui.style "border-radius" "4px"
+        , Ui.style "border-radius" dsRadiusSm
         ]
         [ Html.span
             [ Ui.style "font-family" "'Roboto Mono', monospace"
@@ -1268,22 +1814,28 @@ viewPresetTabBar theme info lookup =
                     activeName == Just name
             in
             Ui.button theme
-                [ Ui.style "padding" "12px 8px 4px"
+                [ Ui.style "padding" "12px 8px 8px"
                 , Ui.style "border-bottom"
                     (if isActive then
-                        "2px solid " ++ theme.textColor
+                        "2px solid " ++ dsBrandBlue
 
                      else
                         "2px solid transparent"
                     )
-                , Ui.style "font-weight" theme.bodyFontWeight
-                , Ui.style "font-size" theme.subHeadingFontSize
-                , Ui.style "color"
+                , Ui.style "font-weight"
                     (if isActive then
-                        theme.textColor
+                        "600"
 
                      else
-                        theme.mutedTextColor
+                        "400"
+                    )
+                , Ui.style "font-size" "13px"
+                , Ui.style "color"
+                    (if isActive then
+                        dsInk
+
+                     else
+                        dsInk3
                     )
                 , Ui.style "cursor" "pointer"
                 , Ui.onClick (ComponentUpdate (info.pick name))
@@ -1293,8 +1845,8 @@ viewPresetTabBar theme info lookup =
     Html.div
         [ Ui.style "display" "flex"
         , Ui.style "flex-direction" "row"
-        , Ui.style "gap" "12px"
-        , Ui.style "padding" "0 12px"
-        , Ui.style "border-bottom" ("1px solid " ++ theme.dividerColor)
+        , Ui.style "gap" dsSpace3
+        , Ui.style "padding" "0 20px"
+        , Ui.style "border-bottom" ("1px solid " ++ dsLine)
         ]
         (List.map tab info.names)

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -1252,7 +1252,118 @@ viewContent model =
         , Ui.style "display" "flex"
         , Ui.style "flex-direction" "column"
         ]
-        (viewHeading model :: viewFramesList model frames)
+        (viewHeading model :: viewBody model frames)
+
+
+{-| The page body. Configurable pages (those with a live component) get a single
+structure regardless of how the author ordered their frames: the live component
+leads, inside a Playground callout, and everything else — specimens, variant
+charts, usage and behaviour notes — drops below it under one **Reference**
+section. Pure token / reference pages (no live component) render their frames
+as-authored.
+-}
+viewBody : Model t e -> List (ProcessedFrame e t) -> List (Html (Msg t e))
+viewBody model frames =
+    case splitLive frames of
+        Just { live, rest } ->
+            viewPlaygroundCallout model live :: referenceSection model rest
+
+        Nothing ->
+            viewFramesList model frames
+
+
+{-| Split a page into its primary live component (the first interactive / presets
+frame) and the reference content that follows it. Returns `Nothing` for pages
+with no live component, leaving them untouched.
+
+The live frame's own preceding subheading (its label, e.g. an author's
+"Playground" heading or a "Default button" specimen label) is dropped — the
+callout supplies its own header — as is any stray "Playground" subheading
+elsewhere. Everything else is preserved in author order for the Reference
+section.
+
+-}
+splitLive : List (ProcessedFrame e t) -> Maybe { live : ProcessedFrame e t, rest : List (ProcessedFrame e t) }
+splitLive frames =
+    case splitAtLive [] frames of
+        Just ( before, live, after ) ->
+            let
+                beforeTrimmed =
+                    case List.reverse before of
+                        (ProcessedSubheading _) :: earlier ->
+                            List.reverse earlier
+
+                        _ ->
+                            before
+
+                rest =
+                    (beforeTrimmed ++ after)
+                        |> List.filter (not << isPlaygroundSubheading)
+            in
+            Just { live = live, rest = rest }
+
+        Nothing ->
+            Nothing
+
+
+splitAtLive : List (ProcessedFrame e t) -> List (ProcessedFrame e t) -> Maybe ( List (ProcessedFrame e t), ProcessedFrame e t, List (ProcessedFrame e t) )
+splitAtLive acc frames =
+    case frames of
+        [] ->
+            Nothing
+
+        frame :: more ->
+            if isLive frame then
+                Just ( List.reverse acc, frame, more )
+
+            else
+                splitAtLive (frame :: acc) more
+
+
+isLive : ProcessedFrame e t -> Bool
+isLive frame =
+    case frame of
+        ProcessedInteractive _ _ _ ->
+            True
+
+        ProcessedPresets _ _ _ ->
+            True
+
+        _ ->
+            False
+
+
+isPlaygroundSubheading : ProcessedFrame e t -> Bool
+isPlaygroundSubheading frame =
+    case frame of
+        ProcessedSubheading label ->
+            String.toLower (String.trim label) == "playground"
+
+        _ ->
+            False
+
+
+referenceSection : Model t e -> List (ProcessedFrame e t) -> List (Html (Msg t e))
+referenceSection model rest =
+    if List.isEmpty rest then
+        []
+
+    else
+        referenceHeading model.theme :: viewFramesList model rest
+
+
+{-| The "Reference" section divider — an uppercase eyebrow on a full-width rule,
+opening the supporting content below the live component.
+-}
+referenceHeading : Theme -> Html (Msg t e)
+referenceHeading theme =
+    Html.div
+        [ Ui.style "margin-top" "48px"
+        , Ui.style "padding-bottom" "10px"
+        , Ui.style "margin-bottom" "4px"
+        , Ui.style "border-bottom" ("1px solid " ++ dsLine)
+        ]
+        [ Html.span (eyebrowStyles theme) [ Html.text "Reference" ] ]
 
 
 viewHeading : Model t e -> Html (Msg t e)
@@ -1390,12 +1501,76 @@ presetBits model internals =
             ( Nothing, identity )
 
 
+{-| Render the page's primary live component as the Playground callout: the
+polished preview container, headed by the Playground icon + title, with the live
+component (left aligned) below. This is the focus of the page and sits directly
+under the heading.
+-}
+viewPlaygroundCallout : Model t e -> ProcessedFrame e t -> Html (Msg t e)
+viewPlaygroundCallout model frame =
+    case frame of
+        ProcessedInteractive _ wrapper internals ->
+            playgroundCallout model.theme Nothing (renderComponentView model internals wrapper identity)
+
+        ProcessedPresets _ wrapper internals ->
+            let
+                ( tabBar, presetWrap ) =
+                    presetBits model internals
+            in
+            playgroundCallout model.theme tabBar (renderComponentView model internals wrapper presetWrap)
+
+        _ ->
+            Html.text ""
+
+
+{-| The Playground callout: `playgroundCard` chrome with a header row (the
+Playground icon + title) inside the same bordered surface, above the live
+component.
+-}
+playgroundCallout : Theme -> Maybe (Html (Msg t e)) -> Html (Msg t e) -> Html (Msg t e)
+playgroundCallout theme maybeTabBar inner =
+    playgroundShell (playgroundHeaderRow theme :: tabBarItems maybeTabBar) inner
+
+
+playgroundHeaderRow : Theme -> Html (Msg t e)
+playgroundHeaderRow theme =
+    Html.div
+        [ Ui.style "display" "flex"
+        , Ui.style "align-items" "center"
+        , Ui.style "gap" dsSpace2
+        , Ui.style "padding" "14px 20px"
+        , Ui.style "border-bottom" ("1px solid " ++ dsLine2)
+        , Ui.style "color" dsInk3
+        ]
+        [ iconBox 18 (Ui.phosphorFlask "")
+        , Html.span
+            [ Ui.style "font-family" theme.fontFamily
+            , Ui.style "font-size" "14px"
+            , Ui.style "font-weight" "600"
+            , Ui.style "color" dsInk2
+            ]
+            [ Html.text "Playground" ]
+        ]
+
+
+tabBarItems : Maybe (Html (Msg t e)) -> List (Html (Msg t e))
+tabBarItems maybeTabBar =
+    case maybeTabBar of
+        Just tabBar ->
+            [ tabBar ]
+
+        Nothing ->
+            []
+
+
 {-| The Playground live-component container: a polished surface (line border,
 radius, soft elevation) holding a single live component, left aligned. The
-component's variant / size / state are driven from the Inspector.
+component's variant / size / state are driven from the Inspector. `topItems` are
+rendered inside the surface above the component (the Playground header row and/or
+a preset tab bar).
 -}
-playgroundCard : Maybe (Html (Msg t e)) -> Html (Msg t e) -> Html (Msg t e)
-playgroundCard maybeTabBar inner =
+playgroundShell : List (Html (Msg t e)) -> Html (Msg t e) -> Html (Msg t e)
+playgroundShell topItems inner =
     Html.div
         [ Ui.style "margin-top" "16px"
         , Ui.style "background" dsSurface
@@ -1404,14 +1579,8 @@ playgroundCard maybeTabBar inner =
         , Ui.style "box-shadow" dsShadow2
         , Ui.style "overflow" "hidden"
         ]
-        (List.concat
-            [ case maybeTabBar of
-                Just tabBar ->
-                    [ tabBar ]
-
-                Nothing ->
-                    []
-            , [ Html.div
+        (topItems
+            ++ [ Html.div
                     [ Ui.style "display" "flex"
                     , Ui.style "flex-direction" "column"
                     , Ui.style "align-items" "flex-start"
@@ -1419,9 +1588,13 @@ playgroundCard maybeTabBar inner =
                     , Ui.style "min-width" "0"
                     ]
                     [ inner ]
-              ]
-            ]
+               ]
         )
+
+
+playgroundCard : Maybe (Html (Msg t e)) -> Html (Msg t e) -> Html (Msg t e)
+playgroundCard maybeTabBar inner =
+    playgroundShell (tabBarItems maybeTabBar) inner
 
 
 {-| A reference / specimen block (variant matrices, size charts). Unlike the

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -679,7 +679,7 @@ shellStylesheet theme =
                 -- control elements carry `cp-control` and set only their own
                 -- typography/layout inline. Error state keeps its inline border,
                 -- which (being inline) still wins over these class rules.
-                , ".cp-control{border:1px solid " ++ theme.line ++ ";border-radius:" ++ theme.radiusMd ++ ";background:" ++ theme.surface ++ ";padding:7px 10px;transition:border-color .12s ease,box-shadow .12s ease;}"
+                , ".cp-control{border:1px solid " ++ theme.line ++ ";border-radius:" ++ theme.radiusSm ++ ";background:" ++ theme.surface ++ ";padding:7px 10px;transition:border-color .12s ease,box-shadow .12s ease;}"
                 , ".cp-control:hover{border-color:" ++ theme.borderHover ++ ";}"
                 , ".cp-control:focus,.cp-control:focus-visible{outline:none;border-color:" ++ theme.brandBlue ++ ";box-shadow:0 0 0 3px " ++ theme.brandBlue50 ++ ";}"
                 , ".cp-control:disabled{background:" ++ theme.surfaceAlt ++ ";color:" ++ theme.ink4 ++ ";cursor:not-allowed;}"

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -741,7 +741,8 @@ viewSearchBand model =
 
 viewNavList : Model t e -> List (Html (Msg t e))
 viewNavList model =
-    orderChildren model.index
+    -- Top-level sections render in source order (the author's section sequence).
+    model.index
         |> List.filter (indexHasMatch model.search)
         |> List.map (viewNavNode model 0)
 
@@ -756,7 +757,7 @@ viewNavNode model depth (Index item) =
             filteredChildren =
                 item.children
                     |> List.filter (indexHasMatch model.search)
-                    |> orderChildren
+                    |> orderChildren depth
 
             -- A search with matches force-opens its groups so results are visible.
             isOpen =
@@ -915,16 +916,23 @@ navIndent depth =
     String.fromInt (8 + depth * 14) ++ "px"
 
 
-{-| Within a parent: leaf pages first (sorted alphabetically by name),
-then groups in source order. Applied at every nesting level.
+{-| Order a node's children for display.
+
+  - A top-level section's catalog (`depth == 0`) is sorted alphabetically by
+    name with pages and groups **interleaved**, so a sub-category (e.g. Button)
+    sits in its natural alphabetical slot among the leaf components rather than
+    being pushed to the end.
+  - Deeper, curated sub-categories (`depth >= 1`, e.g. the pages inside Button)
+    keep their **source order**, so the author controls the sequence.
+
 -}
-orderChildren : List Index -> List Index
-orderChildren children =
-    let
-        ( pages, groups ) =
-            List.partition (\(Index item) -> List.isEmpty item.children) children
-    in
-    List.sortBy (\(Index item) -> String.toLower item.name) pages ++ groups
+orderChildren : Int -> List Index -> List Index
+orderChildren depth children =
+    if depth == 0 then
+        List.sortBy (\(Index item) -> String.toLower item.name) children
+
+    else
+        children
 
 
 indexHasMatch : String -> Index -> Bool

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -548,7 +548,7 @@ view model =
         , Ui.style "background-color" theme.backgroundColor
         , Ui.style "color" theme.textColor
         ]
-        [ shellStylesheet
+        [ shellStylesheet theme
         , viewSidebar model
         , viewMainColumn model inspectables
         , if showInspector then
@@ -632,8 +632,8 @@ activeInspectable model inspectables =
 -- inline, so the breakpoint can win.
 
 
-shellStylesheet : Html msg
-shellStylesheet =
+shellStylesheet : Theme -> Html msg
+shellStylesheet theme =
     Html.node "style"
         []
         [ Html.text <|
@@ -644,22 +644,22 @@ shellStylesheet =
                 -- !important: Ui.button sets `background:none` inline, which would
                 -- otherwise beat these class rules and swallow the hover / selected
                 -- fills.
-                , ".cp-nav-row:hover{background:" ++ dsSurfaceAlt ++ " !important;}"
-                , ".cp-nav-row:focus-visible{outline:2px solid " ++ dsAccent ++ ";outline-offset:-2px;}"
-                , ".cp-nav-row.is-active{background:" ++ dsBrandBlue50 ++ " !important;}"
-                , ".cp-nav-row.is-active:hover{background:" ++ dsBrandBlue50 ++ " !important;}"
-                , ".cp-nav-icon{color:" ++ dsInk2 ++ ";transition:color .12s ease;}"
-                , ".cp-nav-row:hover .cp-nav-icon{color:" ++ dsInk ++ ";}"
-                , ".cp-nav-row.is-active .cp-nav-icon{color:" ++ dsAccent ++ ";}"
-                , ".cp-nav-row.contains-active .cp-nav-icon{color:" ++ dsAccent ++ ";}"
-                , ".cp-nav-chevron{color:" ++ dsInk4 ++ ";transition:color .12s ease;}"
-                , ".cp-nav-row:hover .cp-nav-chevron{color:" ++ dsInk3 ++ ";}"
+                , ".cp-nav-row:hover{background:" ++ theme.surfaceAlt ++ " !important;}"
+                , ".cp-nav-row:focus-visible{outline:2px solid " ++ theme.accent ++ ";outline-offset:-2px;}"
+                , ".cp-nav-row.is-active{background:" ++ theme.brandBlue50 ++ " !important;}"
+                , ".cp-nav-row.is-active:hover{background:" ++ theme.brandBlue50 ++ " !important;}"
+                , ".cp-nav-icon{color:" ++ theme.ink2 ++ ";transition:color .12s ease;}"
+                , ".cp-nav-row:hover .cp-nav-icon{color:" ++ theme.ink ++ ";}"
+                , ".cp-nav-row.is-active .cp-nav-icon{color:" ++ theme.accent ++ ";}"
+                , ".cp-nav-row.contains-active .cp-nav-icon{color:" ++ theme.accent ++ ";}"
+                , ".cp-nav-chevron{color:" ++ theme.ink4 ++ ";transition:color .12s ease;}"
+                , ".cp-nav-row:hover .cp-nav-chevron{color:" ++ theme.ink3 ++ ";}"
                 , ".cp-icon-btn{transition:background-color .12s ease,color .12s ease;}"
-                , ".cp-icon-btn:hover{background:" ++ dsSurfaceAlt ++ ";color:" ++ dsInk ++ ";}"
+                , ".cp-icon-btn:hover{background:" ++ theme.surfaceAlt ++ ";color:" ++ theme.ink ++ ";}"
                 , ".cp-trigger{transition:background-color .12s ease,box-shadow .12s ease,border-color .12s ease;}"
-                , ".cp-trigger:hover{background:" ++ dsSurfaceAlt ++ ";}"
+                , ".cp-trigger:hover{background:" ++ theme.surfaceAlt ++ ";}"
                 , ".cp-search{transition:border-color .12s ease,box-shadow .12s ease;}"
-                , ".cp-search:focus-within{border-color:" ++ dsBrandBlue ++ ";box-shadow:0 0 0 3px " ++ dsBrandBlue50 ++ ";}"
+                , ".cp-search:focus-within{border-color:" ++ theme.brandBlue ++ ";box-shadow:0 0 0 3px " ++ theme.brandBlue50 ++ ";}"
 
                 -- Inspector controls (text fields, selects/booleans). The box
                 -- chrome and every interaction state live here so they are
@@ -667,22 +667,22 @@ shellStylesheet =
                 -- control elements carry `cp-control` and set only their own
                 -- typography/layout inline. Error state keeps its inline border,
                 -- which (being inline) still wins over these class rules.
-                , ".cp-control{border:1px solid " ++ dsLine ++ ";border-radius:" ++ dsRadiusMd ++ ";background:" ++ dsSurface ++ ";padding:7px 10px;transition:border-color .12s ease,box-shadow .12s ease;}"
-                , ".cp-control:hover{border-color:" ++ dsBorderHover ++ ";}"
-                , ".cp-control:focus,.cp-control:focus-visible{outline:none;border-color:" ++ dsBrandBlue ++ ";box-shadow:0 0 0 3px " ++ dsBrandBlue50 ++ ";}"
-                , ".cp-control:disabled{background:" ++ dsSurfaceAlt ++ ";color:" ++ dsInk4 ++ ";cursor:not-allowed;}"
-                , ".cp-control::placeholder{color:" ++ dsInk4 ++ ";}"
+                , ".cp-control{border:1px solid " ++ theme.line ++ ";border-radius:" ++ theme.radiusMd ++ ";background:" ++ theme.surface ++ ";padding:7px 10px;transition:border-color .12s ease,box-shadow .12s ease;}"
+                , ".cp-control:hover{border-color:" ++ theme.borderHover ++ ";}"
+                , ".cp-control:focus,.cp-control:focus-visible{outline:none;border-color:" ++ theme.brandBlue ++ ";box-shadow:0 0 0 3px " ++ theme.brandBlue50 ++ ";}"
+                , ".cp-control:disabled{background:" ++ theme.surfaceAlt ++ ";color:" ++ theme.ink4 ++ ";cursor:not-allowed;}"
+                , ".cp-control::placeholder{color:" ++ theme.ink4 ++ ";}"
 
                 -- The in-field clear control: a glyph that recolours on hover /
                 -- focus rather than gaining its own button chrome, so it reads as
                 -- part of the input.
-                , ".cp-clear{color:" ++ dsInk4 ++ ";transition:color .12s ease;cursor:pointer;}"
-                , ".cp-clear:hover{color:" ++ dsInk ++ ";}"
-                , ".cp-clear:focus-visible{outline:2px solid " ++ dsBrandBlue ++ ";outline-offset:1px;border-radius:" ++ dsRadiusSm ++ ";color:" ++ dsInk ++ ";}"
-                , ".cp-inspector{width:380px;flex-shrink:0;height:100vh;border-left:1px solid " ++ dsLine ++ ";background:" ++ dsSurface ++ ";display:flex;flex-direction:column;animation:cp-slide-in .18s ease;}"
+                , ".cp-clear{color:" ++ theme.ink4 ++ ";transition:color .12s ease;cursor:pointer;}"
+                , ".cp-clear:hover{color:" ++ theme.ink ++ ";}"
+                , ".cp-clear:focus-visible{outline:2px solid " ++ theme.brandBlue ++ ";outline-offset:1px;border-radius:" ++ theme.radiusSm ++ ";color:" ++ theme.ink ++ ";}"
+                , ".cp-inspector{width:380px;flex-shrink:0;height:100vh;border-left:1px solid " ++ theme.line ++ ";background:" ++ theme.surface ++ ";display:flex;flex-direction:column;animation:cp-slide-in .18s ease;}"
                 , ".cp-inspector-body{flex:1;min-height:0;overflow-y:auto;}"
                 , "@keyframes cp-slide-in{from{transform:translateX(28px);opacity:.3;}to{transform:none;opacity:1;}}"
-                , "@media (max-width:1080px){.cp-inspector{position:fixed;top:0;right:0;bottom:0;height:auto;z-index:1000;box-shadow:" ++ dsShadow4 ++ ";}}"
+                , "@media (max-width:1080px){.cp-inspector{position:fixed;top:0;right:0;bottom:0;height:auto;z-index:1000;box-shadow:" ++ theme.shadow4 ++ ";}}"
                 ]
         ]
 
@@ -702,7 +702,7 @@ viewSidebar model =
                 Just content ->
                     [ Html.div
                         [ Ui.style "padding" "16px 20px"
-                        , Ui.style "border-top" ("1px solid " ++ dsLine2)
+                        , Ui.style "border-top" ("1px solid " ++ theme.line2)
                         ]
                         [ Html.map never content ]
                     ]
@@ -714,15 +714,15 @@ viewSidebar model =
         [ Ui.style "width" "300px"
         , Ui.style "flex-shrink" "0"
         , Ui.style "height" "100vh"
-        , Ui.style "background" dsSidebar
-        , Ui.style "border-right" ("1px solid " ++ dsLine)
+        , Ui.style "background" theme.sidebar
+        , Ui.style "border-right" ("1px solid " ++ theme.line)
         ]
         (List.concat
             [ [ Html.div
                     (Ui.headingStyles theme
                         ++ [ Ui.style "padding" "28px 20px 20px 20px"
                            , Ui.style "white-space" "nowrap"
-                           , Ui.style "border-bottom" ("1px solid " ++ dsLine2)
+                           , Ui.style "border-bottom" ("1px solid " ++ theme.line2)
                            ]
                     )
                     [ Html.map never theme.sidebarHeader ]
@@ -774,19 +774,19 @@ viewSearchBand model =
     in
     Html.div
         [ Ui.style "padding" "12px 16px"
-        , Ui.style "border-bottom" ("1px solid " ++ dsLine2)
+        , Ui.style "border-bottom" ("1px solid " ++ theme.line2)
         ]
         [ Html.label
             [ Html.Attributes.class "cp-search"
             , Ui.style "display" "flex"
             , Ui.style "align-items" "center"
-            , Ui.style "gap" dsSpace2
+            , Ui.style "gap" theme.space2
             , Ui.style "height" "38px"
             , Ui.style "padding" "0 12px"
-            , Ui.style "background" dsSurface
-            , Ui.style "border" ("1px solid " ++ dsLine)
-            , Ui.style "border-radius" dsRadiusMd
-            , Ui.style "color" dsInk4
+            , Ui.style "background" theme.surface
+            , Ui.style "border" ("1px solid " ++ theme.line)
+            , Ui.style "border-radius" theme.radiusMd
+            , Ui.style "color" theme.ink4
             ]
             (iconBox 16 (Ui.phosphorMagnifyingGlass "")
                 :: Html.input
@@ -806,7 +806,7 @@ viewSearchBand model =
                     , Ui.style "background-color" "transparent"
                     , Ui.style "font-family" theme.fontFamily
                     , Ui.style "font-size" "14px"
-                    , Ui.style "color" dsInk
+                    , Ui.style "color" theme.ink
                     , Ui.disableAutocomplete
                     ]
                     []
@@ -925,13 +925,13 @@ viewGroupRow model depth item isOpen containsActive =
             , Ui.style "margin-top" "14px"
             , Ui.style "margin-bottom" "2px"
             , Ui.style "padding" "0 8px"
-            , Ui.style "border-radius" dsRadiusMd
+            , Ui.style "border-radius" theme.radiusMd
             , Ui.style "font-family" theme.fontFamily
             , Ui.style "font-size" "11px"
             , Ui.style "font-weight" "700"
             , Ui.style "letter-spacing" "0.07em"
             , Ui.style "text-transform" "uppercase"
-            , Ui.style "color" dsInk4
+            , Ui.style "color" theme.ink4
             , Ui.onClick (ToggleGroup item.id)
             ]
             [ Html.span [] [ Html.text item.name ]
@@ -960,16 +960,16 @@ viewGroupRow model depth item isOpen containsActive =
             , Ui.style "height" "34px"
             , Ui.style "padding-left" (navIndent depth)
             , Ui.style "padding-right" "10px"
-            , Ui.style "border-radius" dsRadiusMd
+            , Ui.style "border-radius" theme.radiusMd
             , Ui.style "font-family" theme.fontFamily
             , Ui.style "font-size" "14px"
             , Ui.style "font-weight" "600"
             , Ui.style "color"
                 (if containsActive then
-                    dsAccent
+                    theme.accent
 
                  else
-                    dsInk2
+                    theme.ink2
                 )
             , Ui.onClick (ToggleGroup item.id)
             ]
@@ -1028,7 +1028,7 @@ viewPageLink model depth meta =
         , Ui.style "height" "34px"
         , Ui.style "padding-left" (navIndent depth)
         , Ui.style "padding-right" "10px"
-        , Ui.style "border-radius" dsRadiusMd
+        , Ui.style "border-radius" theme.radiusMd
         , Ui.style "font-family" theme.fontFamily
         , Ui.style "font-size" "14px"
         , Ui.style "font-weight"
@@ -1040,10 +1040,10 @@ viewPageLink model depth meta =
             )
         , Ui.style "color"
             (if isActive then
-                dsInk
+                theme.ink
 
              else
-                dsInk3
+                theme.ink3
             )
         , Ui.onClick (ViewPage meta.id)
         ]
@@ -1068,7 +1068,7 @@ viewPageLink model depth meta =
                 , Ui.style "height" "6px"
                 , Ui.style "flex-shrink" "0"
                 , Ui.style "border-radius" "50%"
-                , Ui.style "background" dsAccent
+                , Ui.style "background" theme.accent
                 ]
                 []
 
@@ -1116,6 +1116,10 @@ indexHasMatch search (Index item) =
 
 viewMainColumn : Model t e -> List (Inspectable t e) -> Html (Msg t e)
 viewMainColumn model inspectables =
+    let
+        theme =
+            model.theme
+    in
     Ui.vStack
         [ Ui.style "flex-grow" "1"
         , Ui.style "min-width" "0"
@@ -1126,7 +1130,7 @@ viewMainColumn model inspectables =
             [ Ui.style "flex-grow" "1"
             , Ui.style "min-height" "0"
             , Ui.style "overflow-y" "auto"
-            , Ui.style "background" dsAppBg
+            , Ui.style "background" theme.appBg
             ]
             [ viewContent model ]
         ]
@@ -1134,17 +1138,21 @@ viewMainColumn model inspectables =
 
 viewTopRibbon : Model t e -> List (Inspectable t e) -> Html (Msg t e)
 viewTopRibbon model inspectables =
+    let
+        theme =
+            model.theme
+    in
     Html.div
         [ Ui.style "display" "flex"
         , Ui.style "align-items" "center"
         , Ui.style "justify-content" "space-between"
         , Ui.style "flex-shrink" "0"
-        , Ui.style "gap" dsSpace4
+        , Ui.style "gap" theme.space4
         , Ui.style "height" "56px"
         , Ui.style "padding" "0 24px"
-        , Ui.style "background" dsSurface
-        , Ui.style "border-bottom" ("1px solid " ++ dsLine)
-        , Ui.style "box-shadow" dsShadow1
+        , Ui.style "background" theme.surface
+        , Ui.style "border-bottom" ("1px solid " ++ theme.line)
+        , Ui.style "box-shadow" theme.shadow1
         ]
         [ viewBreadcrumbs model
 
@@ -1173,7 +1181,7 @@ viewBreadcrumbs model =
 
         separator =
             Html.span
-                [ Ui.style "color" dsInk4
+                [ Ui.style "color" theme.ink4
                 , Ui.style "font-size" "13px"
                 ]
                 [ Html.text "›" ]
@@ -1195,10 +1203,10 @@ viewBreadcrumbs model =
                     )
                 , Ui.style "color"
                     (if isLast then
-                        dsInk
+                        theme.ink
 
                      else
-                        dsInk3
+                        theme.ink3
                     )
                 , Ui.style "white-space" "nowrap"
                 ]
@@ -1207,11 +1215,11 @@ viewBreadcrumbs model =
     Html.div
         [ Ui.style "display" "flex"
         , Ui.style "align-items" "center"
-        , Ui.style "gap" dsSpace2
+        , Ui.style "gap" theme.space2
         , Ui.style "min-width" "0"
         , Ui.style "overflow" "hidden"
         ]
-        (Html.span [ Ui.style "color" dsInk4 ] [ iconBox 16 (Ui.phosphorHouse "") ]
+        (Html.span [ Ui.style "color" theme.ink4 ] [ iconBox 16 (Ui.phosphorHouse "") ]
             :: List.concat
                 (List.indexedMap
                     (\i meta -> [ separator, crumb i meta ])
@@ -1420,17 +1428,17 @@ referenceHeading theme =
     Html.div
         [ Ui.style "display" "flex"
         , Ui.style "align-items" "center"
-        , Ui.style "gap" dsSpace2
+        , Ui.style "gap" theme.space2
         , Ui.style "margin-top" "48px"
-        , Ui.style "margin-bottom" dsSpace3
-        , Ui.style "color" dsInk3
+        , Ui.style "margin-bottom" theme.space3
+        , Ui.style "color" theme.ink3
         ]
         [ iconBox 22 (Ui.phosphorBookOpen "")
         , Html.span
             [ Ui.style "font-family" theme.fontFamily
             , Ui.style "font-size" "24px"
             , Ui.style "font-weight" "600"
-            , Ui.style "color" dsInk
+            , Ui.style "color" theme.ink
             ]
             [ Html.text "Reference" ]
         ]
@@ -1461,7 +1469,7 @@ viewHeading model =
     Html.div
         [ Ui.style "display" "flex"
         , Ui.style "align-items" "center"
-        , Ui.style "gap" dsSpace4
+        , Ui.style "gap" theme.space4
         , Ui.style "margin-bottom" "8px"
         ]
         [ Html.div
@@ -1471,9 +1479,9 @@ viewHeading model =
             , Ui.style "display" "inline-flex"
             , Ui.style "align-items" "center"
             , Ui.style "justify-content" "center"
-            , Ui.style "background" dsBrandBlue50
-            , Ui.style "border-radius" dsRadiusLg
-            , Ui.style "color" dsBrandBlue
+            , Ui.style "background" theme.brandBlue50
+            , Ui.style "border-radius" theme.radiusLg
+            , Ui.style "color" theme.brandBlue
             ]
             [ iconBox 22 (Ui.phosphorCube "") ]
         , Ui.vStack [ Ui.style "gap" "2px", Ui.style "min-width" "0" ]
@@ -1488,7 +1496,7 @@ viewHeading model =
                         , Ui.style "font-weight" "600"
                         , Ui.style "letter-spacing" "0.06em"
                         , Ui.style "text-transform" "uppercase"
-                        , Ui.style "color" dsInk4
+                        , Ui.style "color" theme.ink4
                         ]
                         [ Html.text subtitle ]
                     ]
@@ -1496,7 +1504,7 @@ viewHeading model =
                         [ Ui.style "font-family" theme.fontFamily
                         , Ui.style "font-size" "28px"
                         , Ui.style "font-weight" "700"
-                        , Ui.style "color" dsInk
+                        , Ui.style "color" theme.ink
                         ]
                         [ Html.text pageName ]
                   ]
@@ -1512,16 +1520,20 @@ viewFramesList model frames =
 
 viewFrame : Model t e -> Bool -> ProcessedFrame e t -> Html (Msg t e)
 viewFrame model isFirst frame =
+    let
+        theme =
+            model.theme
+    in
     case frame of
         ProcessedInteractive _ wrapper internals ->
-            playgroundCard Nothing (renderComponentView model internals wrapper identity)
+            playgroundCard theme Nothing (renderComponentView model internals wrapper identity)
 
         ProcessedPresets _ wrapper internals ->
             let
                 ( tabBar, presetWrap ) =
                     presetBits model internals
             in
-            playgroundCard tabBar (renderComponentView model internals wrapper presetWrap)
+            playgroundCard theme tabBar (renderComponentView model internals wrapper presetWrap)
 
         ProcessedStatic html ->
             Html.div
@@ -1530,15 +1542,15 @@ viewFrame model isFirst frame =
                         "0"
 
                      else
-                        dsSpace2
+                        theme.space2
                     )
-                , Ui.style "color" dsInk3
+                , Ui.style "color" theme.ink3
                 , Ui.style "font-size" "14px"
                 ]
                 [ Html.map ComponentUpdate html ]
 
         ProcessedGallery html ->
-            specimenBlock (Html.map ComponentUpdate html)
+            specimenBlock theme (Html.map ComponentUpdate html)
 
         ProcessedSubheading label ->
             sectionLabel model.theme isFirst label
@@ -1599,7 +1611,7 @@ component.
 -}
 playgroundCallout : Theme -> Maybe (Html (Msg t e)) -> Html (Msg t e) -> Html (Msg t e)
 playgroundCallout theme maybeTabBar inner =
-    playgroundShell (playgroundHeaderRow theme :: tabBarItems maybeTabBar) inner
+    playgroundShell theme (playgroundHeaderRow theme :: tabBarItems maybeTabBar) inner
 
 
 playgroundHeaderRow : Theme -> Html (Msg t e)
@@ -1607,17 +1619,17 @@ playgroundHeaderRow theme =
     Html.div
         [ Ui.style "display" "flex"
         , Ui.style "align-items" "center"
-        , Ui.style "gap" dsSpace2
+        , Ui.style "gap" theme.space2
         , Ui.style "padding" "14px 20px"
-        , Ui.style "border-bottom" ("1px solid " ++ dsLine2)
-        , Ui.style "color" dsInk3
+        , Ui.style "border-bottom" ("1px solid " ++ theme.line2)
+        , Ui.style "color" theme.ink3
         ]
         [ iconBox 18 (Ui.phosphorFlask "")
         , Html.span
             [ Ui.style "font-family" theme.fontFamily
             , Ui.style "font-size" "14px"
             , Ui.style "font-weight" "600"
-            , Ui.style "color" dsInk2
+            , Ui.style "color" theme.ink2
             ]
             [ Html.text "Playground" ]
         ]
@@ -1639,14 +1651,14 @@ component's variant / size / state are driven from the Inspector. `topItems` are
 rendered inside the surface above the component (the Playground header row and/or
 a preset tab bar).
 -}
-playgroundShell : List (Html (Msg t e)) -> Html (Msg t e) -> Html (Msg t e)
-playgroundShell topItems inner =
+playgroundShell : Theme -> List (Html (Msg t e)) -> Html (Msg t e) -> Html (Msg t e)
+playgroundShell theme topItems inner =
     Html.div
         [ Ui.style "margin-top" "16px"
-        , Ui.style "background" dsSurface
-        , Ui.style "border" ("1px solid " ++ dsLine)
-        , Ui.style "border-radius" dsRadiusLg
-        , Ui.style "box-shadow" dsShadow2
+        , Ui.style "background" theme.surface
+        , Ui.style "border" ("1px solid " ++ theme.line)
+        , Ui.style "border-radius" theme.radiusLg
+        , Ui.style "box-shadow" theme.shadow2
 
         -- Visible (not hidden) so an open dropdown / popover menu inside the live
         -- component can float out of the callout instead of being clipped. The
@@ -1667,9 +1679,9 @@ playgroundShell topItems inner =
         )
 
 
-playgroundCard : Maybe (Html (Msg t e)) -> Html (Msg t e) -> Html (Msg t e)
-playgroundCard maybeTabBar inner =
-    playgroundShell (tabBarItems maybeTabBar) inner
+playgroundCard : Theme -> Maybe (Html (Msg t e)) -> Html (Msg t e) -> Html (Msg t e)
+playgroundCard theme maybeTabBar inner =
+    playgroundShell theme (tabBarItems maybeTabBar) inner
 
 
 {-| A reference / specimen block (variant matrices, size charts). Unlike the
@@ -1684,12 +1696,12 @@ horizontal-scroll affordance; any genuinely wide specimen should wrap its own
 content in a scroll container.
 
 -}
-specimenBlock : Html (Msg t e) -> Html (Msg t e)
-specimenBlock html =
+specimenBlock : Theme -> Html (Msg t e) -> Html (Msg t e)
+specimenBlock theme html =
     Html.div
         [ Ui.style "margin-top" "20px"
         , Ui.style "padding-top" "20px"
-        , Ui.style "border-top" ("1px solid " ++ dsLine2)
+        , Ui.style "border-top" ("1px solid " ++ theme.line2)
         , Ui.style "overflow" "visible"
         ]
         [ html ]
@@ -1701,7 +1713,7 @@ sectionLabel theme isFirst label =
         Html.div
             [ Ui.style "display" "flex"
             , Ui.style "align-items" "center"
-            , Ui.style "gap" dsSpace2
+            , Ui.style "gap" theme.space2
             , Ui.style "margin-top"
                 (if isFirst then
                     "20px"
@@ -1709,14 +1721,14 @@ sectionLabel theme isFirst label =
                  else
                     "40px"
                 )
-            , Ui.style "color" dsInk3
+            , Ui.style "color" theme.ink3
             ]
             [ iconBox 18 (Ui.phosphorFlask "")
             , Html.span
                 [ Ui.style "font-family" theme.fontFamily
                 , Ui.style "font-size" "14px"
                 , Ui.style "font-weight" "600"
-                , Ui.style "color" dsInk2
+                , Ui.style "color" theme.ink2
                 ]
                 [ Html.text label ]
             ]
@@ -1729,7 +1741,7 @@ sectionLabel theme isFirst label =
             [ Ui.style "font-family" theme.fontFamily
             , Ui.style "font-size" "16px"
             , Ui.style "font-weight" "600"
-            , Ui.style "color" dsInk
+            , Ui.style "color" theme.ink
             , Ui.style "margin-top"
                 (if isFirst then
                     "20px"
@@ -1767,116 +1779,6 @@ lookupPageName id =
 -- follow, then component settings, then the read-only design-token reference.
 
 
-dsAppBg : String
-dsAppBg =
-    "#FBFBFC"
-
-
-dsSidebar : String
-dsSidebar =
-    "#F8FAF9"
-
-
-dsSurface : String
-dsSurface =
-    "#FEFEFE"
-
-
-dsSurfaceAlt : String
-dsSurfaceAlt =
-    "#F1F0F5"
-
-
-dsLine : String
-dsLine =
-    "#E5E8EC"
-
-
-dsLine2 : String
-dsLine2 =
-    "#EEF0F3"
-
-
-dsBorderHover : String
-dsBorderHover =
-    "#B8C0CC"
-
-
-dsInk : String
-dsInk =
-    "#0A0F22"
-
-
-dsInk2 : String
-dsInk2 =
-    "#3A4149"
-
-
-dsInk3 : String
-dsInk3 =
-    "#5A5D66"
-
-
-dsInk4 : String
-dsInk4 =
-    "#9DA1AC"
-
-
-dsBrandBlue : String
-dsBrandBlue =
-    "#2F7FFE"
-
-
-dsAccent : String
-dsAccent =
-    "#0E53F1"
-
-
-dsBrandBlue50 : String
-dsBrandBlue50 =
-    "#EAF1FF"
-
-
-dsSpace2 : String
-dsSpace2 =
-    "8px"
-
-
-dsSpace3 : String
-dsSpace3 =
-    "12px"
-
-
-dsSpace4 : String
-dsSpace4 =
-    "16px"
-
-
-dsRadiusMd : String
-dsRadiusMd =
-    "8px"
-
-
-dsRadiusLg : String
-dsRadiusLg =
-    "10px"
-
-
-dsShadow1 : String
-dsShadow1 =
-    "0 1px 2px rgba(16,24,40,0.05)"
-
-
-dsShadow2 : String
-dsShadow2 =
-    "0 2px 4px rgba(16,24,40,0.06), 0 4px 8px rgba(16,24,40,0.04)"
-
-
-dsShadow4 : String
-dsShadow4 =
-    "0 8px 16px rgba(16,24,40,0.08), 0 24px 48px rgba(16,24,40,0.12)"
-
-
 iconBox : Int -> Html msg -> Html msg
 iconBox size icon =
     Html.span
@@ -1897,39 +1799,42 @@ inspectorTrigger model =
     let
         open =
             model.inspectorOpen
+
+        theme =
+            model.theme
     in
     Ui.button model.theme
         [ Html.Attributes.class "cp-trigger"
         , Ui.style "display" "inline-flex"
         , Ui.style "align-items" "center"
-        , Ui.style "gap" dsSpace2
+        , Ui.style "gap" theme.space2
         , Ui.style "height" "34px"
         , Ui.style "padding" "0 12px"
         , Ui.style "flex-shrink" "0"
         , Ui.style "background"
             (if open then
-                dsBrandBlue50
+                theme.brandBlue50
 
              else
-                dsSurface
+                theme.surface
             )
         , Ui.style "border"
             ("1px solid "
                 ++ (if open then
-                        dsBrandBlue
+                        theme.brandBlue
 
                     else
-                        dsLine
+                        theme.line
                    )
             )
-        , Ui.style "border-radius" dsRadiusMd
-        , Ui.style "box-shadow" dsShadow1
+        , Ui.style "border-radius" theme.radiusMd
+        , Ui.style "box-shadow" theme.shadow1
         , Ui.style "color"
             (if open then
-                dsBrandBlue
+                theme.brandBlue
 
              else
-                dsInk
+                theme.ink
             )
         , Ui.style "font-size" "13px"
         , Ui.style "font-weight" "600"
@@ -1987,21 +1892,21 @@ inspectorHeader theme =
         , Ui.style "flex-shrink" "0"
         , Ui.style "height" "56px"
         , Ui.style "padding" "0 20px"
-        , Ui.style "border-bottom" ("1px solid " ++ dsLine)
+        , Ui.style "border-bottom" ("1px solid " ++ theme.line)
         ]
         [ Html.span
             [ Ui.style "font-family" theme.fontFamily
             , Ui.style "font-size" "15px"
             , Ui.style "font-weight" "700"
-            , Ui.style "color" dsInk
+            , Ui.style "color" theme.ink
             ]
             [ Html.text "Inspector" ]
         , Ui.button theme
             [ Html.Attributes.class "cp-icon-btn"
             , Ui.style "width" "30px"
             , Ui.style "height" "30px"
-            , Ui.style "border-radius" dsRadiusMd
-            , Ui.style "color" dsInk3
+            , Ui.style "border-radius" theme.radiusMd
+            , Ui.style "color" theme.ink3
             , Html.Attributes.title "Close inspector"
             , Ui.onClick ToggleInspector
             ]
@@ -2016,22 +1921,22 @@ inspectorMetadata theme active =
             Html.div
                 [ Ui.style "display" "flex"
                 , Ui.style "flex-direction" "column"
-                , Ui.style "gap" dsSpace2
+                , Ui.style "gap" theme.space2
                 , Ui.style "padding" "16px 20px"
-                , Ui.style "border-bottom" ("1px solid " ++ dsLine2)
+                , Ui.style "border-bottom" ("1px solid " ++ theme.line2)
                 ]
                 [ Html.div (eyebrowStyles theme) [ Html.text "Component" ]
                 , Html.div
                     [ Ui.style "display" "flex"
                     , Ui.style "align-items" "center"
-                    , Ui.style "gap" dsSpace2
+                    , Ui.style "gap" theme.space2
                     ]
-                    [ Html.span [ Ui.style "color" dsBrandBlue ] [ iconBox 16 (Ui.phosphorCube "") ]
+                    [ Html.span [ Ui.style "color" theme.brandBlue ] [ iconBox 16 (Ui.phosphorCube "") ]
                     , Html.span
                         [ Ui.style "font-family" theme.fontFamily
                         , Ui.style "font-size" "14px"
                         , Ui.style "font-weight" "600"
-                        , Ui.style "color" dsInk
+                        , Ui.style "color" theme.ink
                         ]
                         [ Html.text a.name ]
                     ]
@@ -2039,10 +1944,10 @@ inspectorMetadata theme active =
                     [ Ui.style "align-self" "flex-start"
                     , Ui.style "font-family" "'Roboto Mono', monospace"
                     , Ui.style "font-size" "11px"
-                    , Ui.style "color" dsInk3
-                    , Ui.style "background" dsSurfaceAlt
-                    , Ui.style "border" ("1px solid " ++ dsLine2)
-                    , Ui.style "border-radius" dsRadiusSm
+                    , Ui.style "color" theme.ink3
+                    , Ui.style "background" theme.surfaceAlt
+                    , Ui.style "border" ("1px solid " ++ theme.line2)
+                    , Ui.style "border-radius" theme.radiusSm
                     , Ui.style "padding" "2px 6px"
                     ]
                     [ Html.text a.id ]
@@ -2071,7 +1976,7 @@ inspectorTabs model active inspectables =
                 , Ui.style "border-bottom"
                     ("2px solid "
                         ++ (if isActive then
-                                dsBrandBlue
+                                theme.brandBlue
 
                             else
                                 "transparent"
@@ -2087,10 +1992,10 @@ inspectorTabs model active inspectables =
                     )
                 , Ui.style "color"
                     (if isActive then
-                        dsInk
+                        theme.ink
 
                      else
-                        dsInk3
+                        theme.ink3
                     )
                 , Ui.onClick (SelectInspector inspectable.id)
                 ]
@@ -2099,9 +2004,9 @@ inspectorTabs model active inspectables =
     Html.div
         [ Ui.style "display" "flex"
         , Ui.style "flex-wrap" "wrap"
-        , Ui.style "gap" dsSpace3
+        , Ui.style "gap" theme.space3
         , Ui.style "padding" "0 20px"
-        , Ui.style "border-bottom" ("1px solid " ++ dsLine2)
+        , Ui.style "border-bottom" ("1px solid " ++ theme.line2)
         ]
         (List.map tab inspectables)
 
@@ -2113,23 +2018,18 @@ eyebrowStyles theme =
     , Ui.style "font-weight" "600"
     , Ui.style "letter-spacing" "0.08em"
     , Ui.style "text-transform" "uppercase"
-    , Ui.style "color" dsInk4
+    , Ui.style "color" theme.ink4
     ]
-
-
-dsRadiusSm : String
-dsRadiusSm =
-    "4px"
 
 
 inspectorSection : Theme -> String -> Maybe String -> List (Html msg) -> Html msg
 inspectorSection theme title caption content =
     Html.div
         [ Ui.style "padding" "16px 20px"
-        , Ui.style "border-bottom" ("1px solid " ++ dsLine2)
+        , Ui.style "border-bottom" ("1px solid " ++ theme.line2)
         , Ui.style "display" "flex"
         , Ui.style "flex-direction" "column"
-        , Ui.style "gap" dsSpace3
+        , Ui.style "gap" theme.space3
         ]
         (Html.div (eyebrowStyles theme)
             (Html.text title
@@ -2139,8 +2039,8 @@ inspectorSection theme title caption content =
                                 [ Ui.style "text-transform" "none"
                                 , Ui.style "letter-spacing" "0"
                                 , Ui.style "font-weight" "400"
-                                , Ui.style "color" dsInk4
-                                , Ui.style "margin-left" dsSpace2
+                                , Ui.style "color" theme.ink4
+                                , Ui.style "margin-left" theme.space2
                                 ]
                                 [ Html.text c ]
                             ]
@@ -2152,7 +2052,7 @@ inspectorSection theme title caption content =
             :: [ Html.div
                     [ Ui.style "display" "flex"
                     , Ui.style "flex-direction" "column"
-                    , Ui.style "gap" dsSpace2
+                    , Ui.style "gap" theme.space2
                     ]
                     content
                ]
@@ -2167,11 +2067,15 @@ token metadata, a short note is shown rather than a misleading global list.
 -}
 tokenReference : Model t e -> List Internal.TokenGroup -> Html (Msg t e)
 tokenReference model groups =
+    let
+        theme =
+            model.theme
+    in
     if List.isEmpty groups then
         Html.span
             [ Ui.style "font-family" model.theme.fontFamily
             , Ui.style "font-size" "12px"
-            , Ui.style "color" dsInk4
+            , Ui.style "color" theme.ink4
             ]
             [ Html.text "Token usage isn’t documented for this component yet." ]
 
@@ -2179,7 +2083,7 @@ tokenReference model groups =
         Html.div
             [ Ui.style "display" "flex"
             , Ui.style "flex-direction" "column"
-            , Ui.style "gap" dsSpace2
+            , Ui.style "gap" theme.space2
             ]
             (List.map (tokenGroupView model) groups)
 
@@ -2205,11 +2109,11 @@ tokenGroupView model group =
             , Ui.style "justify-content" "space-between"
             , Ui.style "width" "100%"
             , Ui.style "padding" "4px 6px"
-            , Ui.style "border-radius" dsRadiusSm
+            , Ui.style "border-radius" theme.radiusSm
             , Ui.style "font-family" theme.fontFamily
             , Ui.style "font-size" "11px"
             , Ui.style "font-weight" "600"
-            , Ui.style "color" dsInk2
+            , Ui.style "color" theme.ink2
             , Ui.onClick (ToggleTokenGroup group.category)
             ]
             [ Html.span
@@ -2220,11 +2124,11 @@ tokenGroupView model group =
                 [ Html.text group.category
                 , Html.span
                     [ Ui.style "font-weight" "500"
-                    , Ui.style "color" dsInk4
+                    , Ui.style "color" theme.ink4
                     ]
                     [ Html.text (String.fromInt (List.length group.tokens)) ]
                 ]
-            , Html.span [ Ui.style "color" dsInk4 ]
+            , Html.span [ Ui.style "color" theme.ink4 ]
                 [ iconBox 14
                     (if expanded then
                         Ui.phosphorCaretDown ""
@@ -2249,22 +2153,22 @@ tokenRow theme { name, value } =
         [ Ui.style "display" "flex"
         , Ui.style "align-items" "center"
         , Ui.style "justify-content" "space-between"
-        , Ui.style "gap" dsSpace2
+        , Ui.style "gap" theme.space2
         , Ui.style "padding" "3px 8px"
-        , Ui.style "background" dsSurfaceAlt
-        , Ui.style "border" ("1px solid " ++ dsLine2)
-        , Ui.style "border-radius" dsRadiusSm
+        , Ui.style "background" theme.surfaceAlt
+        , Ui.style "border" ("1px solid " ++ theme.line2)
+        , Ui.style "border-radius" theme.radiusSm
         ]
         [ Html.span
             [ Ui.style "font-family" "'Roboto Mono', monospace"
             , Ui.style "font-size" "11px"
-            , Ui.style "color" dsInk
+            , Ui.style "color" theme.ink
             ]
             [ Html.text name ]
         , Html.span
             [ Ui.style "font-family" theme.fontFamily
             , Ui.style "font-size" "11px"
-            , Ui.style "color" dsInk4
+            , Ui.style "color" theme.ink4
             ]
             [ Html.text value ]
         ]
@@ -2285,7 +2189,7 @@ viewPresetTabBar theme info lookup =
                 [ Ui.style "padding" "12px 8px 8px"
                 , Ui.style "border-bottom"
                     (if isActive then
-                        "2px solid " ++ dsBrandBlue
+                        "2px solid " ++ theme.brandBlue
 
                      else
                         "2px solid transparent"
@@ -2300,10 +2204,10 @@ viewPresetTabBar theme info lookup =
                 , Ui.style "font-size" "13px"
                 , Ui.style "color"
                     (if isActive then
-                        dsInk
+                        theme.ink
 
                      else
-                        dsInk3
+                        theme.ink3
                     )
                 , Ui.style "cursor" "pointer"
                 , Ui.onClick (ComponentUpdate (info.pick name))
@@ -2313,8 +2217,8 @@ viewPresetTabBar theme info lookup =
     Html.div
         [ Ui.style "display" "flex"
         , Ui.style "flex-direction" "row"
-        , Ui.style "gap" dsSpace3
+        , Ui.style "gap" theme.space3
         , Ui.style "padding" "0 20px"
-        , Ui.style "border-bottom" ("1px solid " ++ dsLine)
+        , Ui.style "border-bottom" ("1px solid " ++ theme.line)
         ]
         (List.map tab info.names)

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -52,6 +52,7 @@ import Dict exposing (Dict)
 import Html exposing (Html)
 import Html.Attributes
 import Html.Events
+import Json.Decode as Decode
 import Set exposing (Set)
 import State exposing (State)
 import Url
@@ -78,7 +79,8 @@ type ProcessedFrame e t
 
 
 type Msg t e
-    = ComponentUpdate (Internal.Update t)
+    = NoOp
+    | ComponentUpdate (Internal.Update t)
     | ViewPage String
     | UpdateSearch String
     | ToggleInspector
@@ -395,6 +397,9 @@ toUrl path model =
 update : Msg t e -> Model t e -> ( Model t e, List e )
 update msg model =
     case msg of
+        NoOp ->
+            ( model, [] )
+
         ComponentUpdate (Internal.Update (Internal.ComponentInstance (Internal.ComponentRef componentId) ref) updates) ->
             let
                 modelWithUpdates =
@@ -655,6 +660,13 @@ shellStylesheet =
                 , ".cp-trigger:hover{background:" ++ dsSurfaceAlt ++ ";}"
                 , ".cp-search{transition:border-color .12s ease,box-shadow .12s ease;}"
                 , ".cp-search:focus-within{border-color:" ++ dsBrandBlue ++ ";box-shadow:0 0 0 3px " ++ dsBrandBlue50 ++ ";}"
+
+                -- The in-field clear control: a glyph that recolours on hover /
+                -- focus rather than gaining its own button chrome, so it reads as
+                -- part of the input.
+                , ".cp-clear{color:" ++ dsInk4 ++ ";transition:color .12s ease;cursor:pointer;}"
+                , ".cp-clear:hover{color:" ++ dsInk ++ ";}"
+                , ".cp-clear:focus-visible{outline:2px solid " ++ dsBrandBlue ++ ";outline-offset:1px;border-radius:" ++ dsRadiusSm ++ ";color:" ++ dsInk ++ ";}"
                 , ".cp-inspector{width:380px;flex-shrink:0;height:100vh;border-left:1px solid " ++ dsLine ++ ";background:" ++ dsSurface ++ ";display:flex;flex-direction:column;animation:cp-slide-in .18s ease;}"
                 , ".cp-inspector-body{flex:1;min-height:0;overflow-y:auto;}"
                 , "@keyframes cp-slide-in{from{transform:translateX(28px);opacity:.3;}to{transform:none;opacity:1;}}"
@@ -721,8 +733,37 @@ viewSearchBand model =
     let
         theme =
             model.theme
+
+        hasText =
+            model.search /= ""
+
+        clearButton =
+            if hasText then
+                [ Ui.button theme
+                    [ Html.Attributes.class "cp-clear"
+                    , Html.Attributes.type_ "button"
+                    , Html.Attributes.attribute "aria-label" "Clear search"
+                    , Ui.style "display" "inline-flex"
+                    , Ui.style "align-items" "center"
+                    , Ui.style "justify-content" "center"
+                    , Ui.style "flex-shrink" "0"
+
+                    -- Clear on click (covers mouse and keyboard Enter/Space), and
+                    -- swallow the mousedown default so a pointer press doesn't blur
+                    -- the input — focus stays in the field after clearing.
+                    , Html.Events.onClick (UpdateSearch "")
+                    , Html.Events.preventDefaultOn "mousedown" (Decode.succeed ( NoOp, True ))
+                    ]
+                    [ iconBox 14 (Ui.phosphorX "") ]
+                ]
+
+            else
+                []
     in
-    Html.div [ Ui.style "padding" "12px 16px" ]
+    Html.div
+        [ Ui.style "padding" "12px 16px"
+        , Ui.style "border-bottom" ("1px solid " ++ dsLine2)
+        ]
         [ Html.label
             [ Html.Attributes.class "cp-search"
             , Ui.style "display" "flex"
@@ -735,26 +776,48 @@ viewSearchBand model =
             , Ui.style "border-radius" dsRadiusMd
             , Ui.style "color" dsInk4
             ]
-            [ iconBox 16 (Ui.phosphorMagnifyingGlass "")
-            , Html.input
-                [ Html.Attributes.placeholder "Search components…"
-                , Html.Attributes.value model.search
-                , Html.Events.onInput UpdateSearch
-                , Html.Attributes.id "playground-search"
-                , Ui.style "border" "none"
-                , Ui.style "outline" "none"
-                , Ui.style "padding" "0"
-                , Ui.style "flex-grow" "1"
-                , Ui.style "min-width" "0"
-                , Ui.style "background-color" "transparent"
-                , Ui.style "font-family" theme.fontFamily
-                , Ui.style "font-size" "14px"
-                , Ui.style "color" dsInk
-                , Ui.disableAutocomplete
-                ]
-                []
-            ]
+            (iconBox 16 (Ui.phosphorMagnifyingGlass "")
+                :: Html.input
+                    [ Html.Attributes.placeholder "Search components…"
+                    , Html.Attributes.value model.search
+                    , Html.Events.onInput UpdateSearch
+                    , Html.Attributes.id "playground-search"
+
+                    -- Escape clears the field too — the keyboard path that keeps
+                    -- focus in the input (the field never loses focus).
+                    , onEscape (UpdateSearch "")
+                    , Ui.style "border" "none"
+                    , Ui.style "outline" "none"
+                    , Ui.style "padding" "0"
+                    , Ui.style "flex-grow" "1"
+                    , Ui.style "min-width" "0"
+                    , Ui.style "background-color" "transparent"
+                    , Ui.style "font-family" theme.fontFamily
+                    , Ui.style "font-size" "14px"
+                    , Ui.style "color" dsInk
+                    , Ui.disableAutocomplete
+                    ]
+                    []
+                :: clearButton
+            )
         ]
+
+
+{-| Fire `msg` when the Escape key is pressed in an input.
+-}
+onEscape : Msg t e -> Html.Attribute (Msg t e)
+onEscape msg =
+    Html.Events.on "keydown"
+        (Decode.field "key" Decode.string
+            |> Decode.andThen
+                (\key ->
+                    if key == "Escape" then
+                        Decode.succeed msg
+
+                    else
+                        Decode.fail "non-escape key"
+                )
+        )
 
 
 viewNavList : Model t e -> List (Html (Msg t e))
@@ -1072,7 +1135,10 @@ viewTopRibbon model inspectables =
         , Ui.style "box-shadow" dsShadow1
         ]
         [ viewBreadcrumbs model
-        , if List.isEmpty inspectables then
+
+        -- The ribbon trigger only reopens the Inspector — while the panel is open
+        -- it is redundant (the panel has its own close control), so hide it.
+        , if List.isEmpty inspectables || model.inspectorOpen then
             Html.text ""
 
           else

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -66,8 +66,8 @@ import Url.Parser.Query
 
 
 type ProcessedFrame e t
-    = ProcessedInteractive { id : String } (Html (Update t) -> Html (Update t)) (ComponentE e t)
-    | ProcessedPresets { id : String } (Html (Update t) -> Html (Update t)) (ComponentE e t)
+    = ProcessedInteractive { id : String, name : String } (Html (Update t) -> Html (Update t)) (ComponentE e t)
+    | ProcessedPresets { id : String, name : String } (Html (Update t) -> Html (Update t)) (ComponentE e t)
     | ProcessedStatic (Html (Update t))
     | ProcessedGallery (Html (Update t))
     | ProcessedSubheading String
@@ -292,10 +292,10 @@ processFrame : Library e t -> Frame e t -> State Ref (ProcessedFrame e t)
 processFrame lib frame =
     case frame of
         InteractiveFrame meta f wrapper ->
-            State.map (ProcessedInteractive { id = meta.id } wrapper) (f lib)
+            State.map (ProcessedInteractive { id = meta.id, name = meta.name } wrapper) (f lib)
 
         PresetsFrame meta f wrapper ->
-            State.map (ProcessedPresets { id = meta.id } wrapper) (f lib)
+            State.map (ProcessedPresets { id = meta.id, name = meta.name } wrapper) (f lib)
 
         StaticFrame html ->
             State.state (ProcessedStatic html)
@@ -626,8 +626,47 @@ viewPage model =
                    ]
             )
             [ Html.text pageName ]
-            :: List.map (viewFrame model) frames
+            :: viewFramesIndexed model frames
         )
+
+
+{-| Render the page's frames, assigning each inspectable (interactive / presets)
+frame a sequential index so their viewport-pinned inspectors stack instead of
+overlapping. Non-inspectable frames don't advance the counter.
+-}
+viewFramesIndexed : Model t e -> List (ProcessedFrame e t) -> List (Html (Msg t e))
+viewFramesIndexed model frames =
+    frames
+        |> List.foldl
+            (\frame ( idx, acc ) ->
+                if isInspectableFrame frame then
+                    ( idx + 1, viewFrame model idx frame :: acc )
+
+                else
+                    ( idx, viewFrame model idx frame :: acc )
+            )
+            ( 0, [] )
+        |> Tuple.second
+        |> List.reverse
+
+
+isInspectableFrame : ProcessedFrame e t -> Bool
+isInspectableFrame frame =
+    case frame of
+        ProcessedInteractive _ _ _ ->
+            True
+
+        ProcessedPresets _ _ _ ->
+            True
+
+        ProcessedStatic _ ->
+            False
+
+        ProcessedGallery _ ->
+            False
+
+        ProcessedSubheading _ ->
+            False
 
 
 lookupPageName : String -> List Index -> Maybe String
@@ -741,14 +780,14 @@ viewPageLink model meta =
         [ Html.text meta.name ]
 
 
-viewFrame : Model t e -> ProcessedFrame e t -> Html (Msg t e)
-viewFrame model frame =
+viewFrame : Model t e -> Int -> ProcessedFrame e t -> Html (Msg t e)
+viewFrame model inspectorIndex frame =
     case frame of
         ProcessedInteractive meta wrapper internals ->
-            viewInteractiveFrame model meta wrapper internals
+            viewInteractiveFrame model inspectorIndex meta wrapper internals
 
         ProcessedPresets meta wrapper internals ->
-            viewPresetsFrame model meta wrapper internals
+            viewPresetsFrame model inspectorIndex meta wrapper internals
 
         ProcessedStatic html ->
             Html.div
@@ -774,11 +813,13 @@ viewFrame model frame =
                 [ Html.text label ]
 
 
-viewInteractiveFrame : Model t e -> { id : String } -> (Html (Update t) -> Html (Update t)) -> ComponentE e t -> Html (Msg t e)
-viewInteractiveFrame model meta wrapper internals =
+viewInteractiveFrame : Model t e -> Int -> { id : String, name : String } -> (Html (Update t) -> Html (Update t)) -> ComponentE e t -> Html (Msg t e)
+viewInteractiveFrame model inspectorIndex meta wrapper internals =
     viewFramedComponent
         { model = model
         , frameId = meta.id
+        , frameName = meta.name
+        , inspectorIndex = inspectorIndex
         , wrapper = wrapper
         , internals = internals
         , viewPrefix = Nothing
@@ -787,8 +828,8 @@ viewInteractiveFrame model meta wrapper internals =
         }
 
 
-viewPresetsFrame : Model t e -> { id : String } -> (Html (Update t) -> Html (Update t)) -> ComponentE e t -> Html (Msg t e)
-viewPresetsFrame model meta wrapper internals =
+viewPresetsFrame : Model t e -> Int -> { id : String, name : String } -> (Html (Update t) -> Html (Update t)) -> ComponentE e t -> Html (Msg t e)
+viewPresetsFrame model inspectorIndex meta wrapper internals =
     let
         ( tabBar, activePresetWrap ) =
             case internals.presets of
@@ -809,6 +850,8 @@ viewPresetsFrame model meta wrapper internals =
     viewFramedComponent
         { model = model
         , frameId = meta.id
+        , frameName = meta.name
+        , inspectorIndex = inspectorIndex
         , wrapper = wrapper
         , internals = internals
         , viewPrefix = tabBar
@@ -820,6 +863,8 @@ viewPresetsFrame model meta wrapper internals =
 viewFramedComponent :
     { model : Model t e
     , frameId : String
+    , frameName : String
+    , inspectorIndex : Int
     , wrapper : Html (Update t) -> Html (Update t)
     , internals : ComponentE e t
     , viewPrefix : Maybe (Html (Msg t e))
@@ -866,23 +911,29 @@ viewFramedComponent cfg =
                         ]
                 )
 
-        -- The inspector floats over the top-right of the frame so it never
-        -- pushes the component down; closed it is a labelled trigger, open it
-        -- is a full property panel.
+        -- The inspector is pinned to the viewport (position: fixed) at the
+        -- top-right, so it stays put while the page scrolls and never pushes
+        -- the component down. When a page has several inspectors they stack
+        -- downward by inspectorIndex (44px slots) so triggers never overlap.
+        inspectorTop =
+            "calc(16px + " ++ String.fromInt (cfg.inspectorIndex * 44) ++ "px)"
+
         inspector =
             Html.div
-                [ Ui.style "position" "absolute"
-                , Ui.style "top" dsSpace4
+                [ Ui.style "position" "fixed"
+                , Ui.style "top" inspectorTop
                 , Ui.style "right" dsSpace4
-                , Ui.style "z-index" "20"
+                , Ui.style "z-index" "1000"
                 ]
                 [ if controlsShown then
                     inspectorPanel theme
+                        cfg.frameName
                         cfg.frameId
+                        cfg.inspectorIndex
                         (List.map (Html.map ComponentUpdate) (cfg.controlsList theme lookup))
 
                   else
-                    inspectorTrigger theme cfg.frameId
+                    inspectorTrigger theme cfg.frameName cfg.frameId
                 ]
     in
     Html.div
@@ -985,8 +1036,8 @@ iconBox icon =
 {-| Closed state — a discoverable, labelled "Inspector" trigger (design-system
 button: surface, line border, radius-md, shadow).
 -}
-inspectorTrigger : Theme -> String -> Html (Msg t e)
-inspectorTrigger theme frameId =
+inspectorTrigger : Theme -> String -> String -> Html (Msg t e)
+inspectorTrigger theme frameName frameId =
     Ui.button theme
         [ Ui.style "display" "inline-flex"
         , Ui.style "align-items" "center"
@@ -1000,7 +1051,7 @@ inspectorTrigger theme frameId =
         , Ui.style "color" dsInk
         , Ui.style "font-size" "13px"
         , Ui.style "font-weight" "500"
-        , Html.Attributes.title "Open inspector"
+        , Html.Attributes.title ("Inspect " ++ frameName)
         , Ui.onClick (ToggleFrameControls frameId)
         ]
         [ iconBox (Ui.lucideSettings2 ""), Html.text "Inspector" ]
@@ -1010,12 +1061,12 @@ inspectorTrigger theme frameId =
 (radius-lg, shadow-4, line border) that grows with content up to the viewport
 and then scrolls internally, while the panel itself stays put.
 -}
-inspectorPanel : Theme -> String -> List (Html (Msg t e)) -> Html (Msg t e)
-inspectorPanel theme frameId controls =
+inspectorPanel : Theme -> String -> String -> Int -> List (Html (Msg t e)) -> Html (Msg t e)
+inspectorPanel theme frameName frameId inspectorIndex controls =
     Html.div
         [ Ui.style "width" "334px"
         , Ui.style "max-width" "calc(100vw - 32px)"
-        , Ui.style "max-height" "calc(100vh - 32px)"
+        , Ui.style "max-height" ("calc(100vh - 32px - " ++ String.fromInt (inspectorIndex * 44) ++ "px)")
         , Ui.style "overflow-y" "auto"
         , Ui.style "background" dsSurface
         , Ui.style "border" ("1px solid " ++ dsLine)
@@ -1024,15 +1075,15 @@ inspectorPanel theme frameId controls =
         , Ui.style "display" "flex"
         , Ui.style "flex-direction" "column"
         ]
-        [ inspectorHeader theme frameId
+        [ inspectorHeader theme frameName frameId
         , inspectorSection theme "Component Settings" Nothing controls
         , inspectorSection theme "Design Tokens" (Just "Design-system token reference") [ tokenReference theme ]
-        , inspectorSection theme "Component Metadata" Nothing [ metadataRow theme "Source" frameId ]
+        , inspectorSection theme "Component Metadata" Nothing [ metadataRow theme "Component" frameName, metadataRow theme "Source" frameId ]
         ]
 
 
-inspectorHeader : Theme -> String -> Html (Msg t e)
-inspectorHeader theme frameId =
+inspectorHeader : Theme -> String -> String -> Html (Msg t e)
+inspectorHeader theme frameName frameId =
     Html.div
         [ Ui.style "position" "sticky"
         , Ui.style "top" "0"
@@ -1044,13 +1095,29 @@ inspectorHeader theme frameId =
         , Ui.style "border-bottom" ("1px solid " ++ dsLine)
         , Ui.style "z-index" "1"
         ]
-        [ Html.span
-            [ Ui.style "font-family" theme.fontFamily
-            , Ui.style "font-size" "13px"
-            , Ui.style "font-weight" "600"
-            , Ui.style "color" dsInk
+        [ Html.div
+            [ Ui.style "display" "flex"
+            , Ui.style "flex-direction" "column"
+            , Ui.style "gap" "1px"
+            , Ui.style "min-width" "0"
             ]
-            [ Html.text "Inspector" ]
+            [ Html.span
+                [ Ui.style "font-family" theme.fontFamily
+                , Ui.style "font-size" "13px"
+                , Ui.style "font-weight" "600"
+                , Ui.style "color" dsInk
+                ]
+                [ Html.text "Inspector" ]
+            , Html.span
+                [ Ui.style "font-family" theme.fontFamily
+                , Ui.style "font-size" "11px"
+                , Ui.style "color" dsInk4
+                , Ui.style "overflow" "hidden"
+                , Ui.style "text-overflow" "ellipsis"
+                , Ui.style "white-space" "nowrap"
+                ]
+                [ Html.text frameName ]
+            ]
         , Ui.button theme
             [ Ui.style "width" "28px"
             , Ui.style "height" "28px"

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -635,10 +635,14 @@ shellStylesheet =
             String.join "\n"
                 [ ".cp-root, .cp-root *{box-sizing:border-box;}"
                 , ".cp-nav-row{transition:background-color .12s ease,color .12s ease;}"
-                , ".cp-nav-row:hover{background:" ++ dsSurfaceAlt ++ ";}"
+
+                -- !important: Ui.button sets `background:none` inline, which would
+                -- otherwise beat these class rules and swallow the hover / selected
+                -- fills.
+                , ".cp-nav-row:hover{background:" ++ dsSurfaceAlt ++ " !important;}"
                 , ".cp-nav-row:focus-visible{outline:2px solid " ++ dsAccent ++ ";outline-offset:-2px;}"
-                , ".cp-nav-row.is-active{background:" ++ dsBrandBlue50 ++ ";}"
-                , ".cp-nav-row.is-active:hover{background:" ++ dsBrandBlue50 ++ ";}"
+                , ".cp-nav-row.is-active{background:" ++ dsBrandBlue50 ++ " !important;}"
+                , ".cp-nav-row.is-active:hover{background:" ++ dsBrandBlue50 ++ " !important;}"
                 , ".cp-nav-icon{color:" ++ dsInk2 ++ ";transition:color .12s ease;}"
                 , ".cp-nav-row:hover .cp-nav-icon{color:" ++ dsInk ++ ";}"
                 , ".cp-nav-row.is-active .cp-nav-icon{color:" ++ dsAccent ++ ";}"

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -850,9 +850,7 @@ viewFramedComponent cfg =
 
         componentColumn =
             Ui.vStack
-                [ Ui.style "flex-grow" "1"
-                , Ui.style "min-width" "0"
-                ]
+                [ Ui.style "min-width" "0" ]
                 (case cfg.viewPrefix of
                     Just prefix ->
                         [ prefix
@@ -868,64 +866,326 @@ viewFramedComponent cfg =
                         ]
                 )
 
-        toggleIcon =
-            Ui.button theme
-                [ Ui.style "width" "24px"
-                , Ui.style "height" "24px"
-                , Ui.style "display" "inline-flex"
-                , Ui.style "align-items" "center"
-                , Ui.style "justify-content" "center"
-                , Ui.style "flex-shrink" "0"
-                , Ui.onClick (ToggleFrameControls cfg.frameId)
-                ]
-                [ Ui.lucideSettings2 "" ]
-
-        toggleHeader =
+        -- The inspector floats over the top-right of the frame so it never
+        -- pushes the component down; closed it is a labelled trigger, open it
+        -- is a full property panel.
+        inspector =
             Html.div
-                [ Ui.style "position" "sticky"
-                , Ui.style "top" "0"
-                , Ui.style "padding" "16px 24px 16px 20px"
-                , Ui.style "background-color" theme.backgroundColor
-                , Ui.style "display" "flex"
-                , Ui.style "justify-content" "flex-end"
-                , Ui.style "z-index" "1"
-                , Ui.style "flex-shrink" "0"
+                [ Ui.style "position" "absolute"
+                , Ui.style "top" dsSpace4
+                , Ui.style "right" dsSpace4
+                , Ui.style "z-index" "20"
                 ]
-                [ toggleIcon ]
-
-        controlsColumn =
-            if controlsShown then
-                Ui.vStack
-                    [ Ui.style "width" "334px"
-                    , Ui.style "flex-shrink" "0"
-                    , Ui.style "max-height" "50vh"
-                    , Ui.style "overflow-y" "auto"
-                    , Ui.style "border-left" ("1px solid " ++ theme.dividerColor)
-                    ]
-                    [ toggleHeader
-                    , Ui.vStack
-                        [ Ui.style "padding" "16px 24px 16px 20px"
-                        , Ui.style "gap" "8px"
-                        , Ui.style "width" "100%"
-                        ]
+                [ if controlsShown then
+                    inspectorPanel theme
+                        cfg.frameId
                         (List.map (Html.map ComponentUpdate) (cfg.controlsList theme lookup))
-                    ]
 
-            else
-                Html.div
-                    [ Ui.style "flex-shrink" "0"
-                    , Ui.style "border-left" ("1px solid " ++ theme.dividerColor)
-                    ]
-                    [ toggleHeader ]
+                  else
+                    inspectorTrigger theme cfg.frameId
+                ]
     in
     Html.div
-        [ Ui.style "display" "flex"
-        , Ui.style "flex-direction" "row"
-        , Ui.style "align-items" "stretch"
+        [ Ui.style "position" "relative"
         , Ui.style "border-bottom" ("1px solid " ++ theme.dividerColor)
         ]
         [ componentColumn
-        , controlsColumn
+        , inspector
+        ]
+
+
+
+-- INSPECTOR
+-- The playground's property panel. Styled with the design-system token values
+-- (surface / line / ink / radius / elevation / spacing) so the inspector is
+-- itself an example of correct design-system usage.
+
+
+dsSurface : String
+dsSurface =
+    "#FFFFFF"
+
+
+dsSurfaceAlt : String
+dsSurfaceAlt =
+    "#F7F8FA"
+
+
+dsLine : String
+dsLine =
+    "#E5E8EC"
+
+
+dsLine2 : String
+dsLine2 =
+    "#EEF0F3"
+
+
+dsInk : String
+dsInk =
+    "#202326"
+
+
+dsInk3 : String
+dsInk3 =
+    "#5B6470"
+
+
+dsInk4 : String
+dsInk4 =
+    "#8A94A0"
+
+
+dsBrandBlue : String
+dsBrandBlue =
+    "#2F7FFE"
+
+
+dsBrandBlue50 : String
+dsBrandBlue50 =
+    "#EAF2FF"
+
+
+dsSpace2 : String
+dsSpace2 =
+    "8px"
+
+
+dsSpace3 : String
+dsSpace3 =
+    "12px"
+
+
+dsSpace4 : String
+dsSpace4 =
+    "16px"
+
+
+dsShadow2 : String
+dsShadow2 =
+    "0 2px 4px rgba(16,24,40,0.06), 0 4px 8px rgba(16,24,40,0.04)"
+
+
+dsShadow4 : String
+dsShadow4 =
+    "0 8px 16px rgba(16,24,40,0.08), 0 24px 48px rgba(16,24,40,0.12)"
+
+
+iconBox : Html msg -> Html msg
+iconBox icon =
+    Html.span
+        [ Ui.style "width" "16px"
+        , Ui.style "height" "16px"
+        , Ui.style "display" "inline-flex"
+        , Ui.style "flex-shrink" "0"
+        ]
+        [ icon ]
+
+
+{-| Closed state — a discoverable, labelled "Inspector" trigger (design-system
+button: surface, line border, radius-md, shadow).
+-}
+inspectorTrigger : Theme -> String -> Html (Msg t e)
+inspectorTrigger theme frameId =
+    Ui.button theme
+        [ Ui.style "display" "inline-flex"
+        , Ui.style "align-items" "center"
+        , Ui.style "gap" dsSpace2
+        , Ui.style "height" "32px"
+        , Ui.style "padding" "0 12px"
+        , Ui.style "background" dsSurface
+        , Ui.style "border" ("1px solid " ++ dsLine)
+        , Ui.style "border-radius" "6px"
+        , Ui.style "box-shadow" dsShadow2
+        , Ui.style "color" dsInk
+        , Ui.style "font-size" "13px"
+        , Ui.style "font-weight" "500"
+        , Html.Attributes.title "Open inspector"
+        , Ui.onClick (ToggleFrameControls frameId)
+        ]
+        [ iconBox (Ui.lucideSettings2 ""), Html.text "Inspector" ]
+
+
+{-| Open state — the floating property panel: a single design-system surface
+(radius-lg, shadow-4, line border) that grows with content up to the viewport
+and then scrolls internally, while the panel itself stays put.
+-}
+inspectorPanel : Theme -> String -> List (Html (Msg t e)) -> Html (Msg t e)
+inspectorPanel theme frameId controls =
+    Html.div
+        [ Ui.style "width" "334px"
+        , Ui.style "max-width" "calc(100vw - 32px)"
+        , Ui.style "max-height" "calc(100vh - 32px)"
+        , Ui.style "overflow-y" "auto"
+        , Ui.style "background" dsSurface
+        , Ui.style "border" ("1px solid " ++ dsLine)
+        , Ui.style "border-radius" "8px"
+        , Ui.style "box-shadow" dsShadow4
+        , Ui.style "display" "flex"
+        , Ui.style "flex-direction" "column"
+        ]
+        [ inspectorHeader theme frameId
+        , inspectorSection theme "Component Settings" Nothing controls
+        , inspectorSection theme "Design Tokens" (Just "Design-system token reference") [ tokenReference theme ]
+        , inspectorSection theme "Component Metadata" Nothing [ metadataRow theme "Source" frameId ]
+        ]
+
+
+inspectorHeader : Theme -> String -> Html (Msg t e)
+inspectorHeader theme frameId =
+    Html.div
+        [ Ui.style "position" "sticky"
+        , Ui.style "top" "0"
+        , Ui.style "display" "flex"
+        , Ui.style "align-items" "center"
+        , Ui.style "justify-content" "space-between"
+        , Ui.style "padding" (dsSpace3 ++ " " ++ dsSpace4)
+        , Ui.style "background" dsSurface
+        , Ui.style "border-bottom" ("1px solid " ++ dsLine)
+        , Ui.style "z-index" "1"
+        ]
+        [ Html.span
+            [ Ui.style "font-family" theme.fontFamily
+            , Ui.style "font-size" "13px"
+            , Ui.style "font-weight" "600"
+            , Ui.style "color" dsInk
+            ]
+            [ Html.text "Inspector" ]
+        , Ui.button theme
+            [ Ui.style "width" "28px"
+            , Ui.style "height" "28px"
+            , Ui.style "display" "inline-flex"
+            , Ui.style "align-items" "center"
+            , Ui.style "justify-content" "center"
+            , Ui.style "background" dsBrandBlue50
+            , Ui.style "border-radius" "6px"
+            , Ui.style "color" dsBrandBlue
+            , Html.Attributes.title "Close inspector"
+            , Ui.onClick (ToggleFrameControls frameId)
+            ]
+            [ iconBox (Ui.lucideSettings2 "") ]
+        ]
+
+
+inspectorSection : Theme -> String -> Maybe String -> List (Html msg) -> Html msg
+inspectorSection theme title caption content =
+    Html.div
+        [ Ui.style "padding" dsSpace4
+        , Ui.style "border-bottom" ("1px solid " ++ dsLine2)
+        , Ui.style "display" "flex"
+        , Ui.style "flex-direction" "column"
+        , Ui.style "gap" dsSpace3
+        ]
+        (Html.div
+            [ Ui.style "font-family" theme.fontFamily
+            , Ui.style "font-size" "10px"
+            , Ui.style "font-weight" "600"
+            , Ui.style "letter-spacing" "0.08em"
+            , Ui.style "text-transform" "uppercase"
+            , Ui.style "color" dsInk4
+            ]
+            (Html.text title
+                :: (case caption of
+                        Just c ->
+                            [ Html.span
+                                [ Ui.style "text-transform" "none"
+                                , Ui.style "letter-spacing" "0"
+                                , Ui.style "font-weight" "400"
+                                , Ui.style "color" dsInk4
+                                , Ui.style "margin-left" dsSpace2
+                                ]
+                                [ Html.text c ]
+                            ]
+
+                        Nothing ->
+                            []
+                   )
+            )
+            :: [ Html.div
+                    [ Ui.style "display" "flex"
+                    , Ui.style "flex-direction" "column"
+                    , Ui.style "gap" dsSpace2
+                    ]
+                    content
+               ]
+        )
+
+
+metadataRow : Theme -> String -> String -> Html msg
+metadataRow theme name value =
+    Html.div
+        [ Ui.style "display" "flex"
+        , Ui.style "justify-content" "space-between"
+        , Ui.style "gap" dsSpace3
+        , Ui.style "font-family" theme.fontFamily
+        , Ui.style "font-size" "12px"
+        ]
+        [ Html.span [ Ui.style "color" dsInk3 ] [ Html.text name ]
+        , Html.span [ Ui.style "color" dsInk, Ui.style "font-weight" "500" ] [ Html.text value ]
+        ]
+
+
+{-| A read-only reference of the design-system token vocabulary, grouped by
+category. The framework treats components as opaque render functions, so this is
+the token vocabulary — not a per-component usage filter.
+-}
+tokenReference : Theme -> Html msg
+tokenReference theme =
+    Html.div
+        [ Ui.style "display" "flex"
+        , Ui.style "flex-direction" "column"
+        , Ui.style "gap" dsSpace3
+        ]
+        [ tokenGroup theme "Typography" [ ( "text-xs", "12px" ), ( "text-sm", "14px" ), ( "text-base", "16px" ), ( "text-lg", "18px" ) ]
+        , tokenGroup theme "Colour" [ ( "pw-surface", dsSurface ), ( "pw-surface-alt", dsSurfaceAlt ), ( "pw-ink", dsInk ), ( "pw-ink-3", dsInk3 ), ( "pw-line", dsLine ) ]
+        , tokenGroup theme "Radius" [ ( "rounded-sm", "4px" ), ( "rounded-md", "6px" ), ( "rounded-lg", "8px" ) ]
+        , tokenGroup theme "Elevation" [ ( "shadow-1", "" ), ( "shadow-2", "" ), ( "shadow-3", "" ), ( "shadow-4", "" ) ]
+        , tokenGroup theme "Spacing" [ ( "space-1", "4px" ), ( "space-2", "8px" ), ( "space-3", "12px" ), ( "space-4", "16px" ) ]
+        ]
+
+
+tokenGroup : Theme -> String -> List ( String, String ) -> Html msg
+tokenGroup theme groupName rows =
+    Html.div
+        [ Ui.style "display" "flex"
+        , Ui.style "flex-direction" "column"
+        , Ui.style "gap" "4px"
+        ]
+        (Html.div
+            [ Ui.style "font-family" theme.fontFamily
+            , Ui.style "font-size" "11px"
+            , Ui.style "font-weight" "600"
+            , Ui.style "color" dsInk3
+            ]
+            [ Html.text groupName ]
+            :: List.map (tokenRow theme) rows
+        )
+
+
+tokenRow : Theme -> ( String, String ) -> Html msg
+tokenRow theme ( name, value ) =
+    Html.div
+        [ Ui.style "display" "flex"
+        , Ui.style "align-items" "center"
+        , Ui.style "justify-content" "space-between"
+        , Ui.style "gap" dsSpace2
+        , Ui.style "padding" "3px 8px"
+        , Ui.style "background" dsSurfaceAlt
+        , Ui.style "border" ("1px solid " ++ dsLine2)
+        , Ui.style "border-radius" "4px"
+        ]
+        [ Html.span
+            [ Ui.style "font-family" "'Roboto Mono', monospace"
+            , Ui.style "font-size" "11px"
+            , Ui.style "color" dsInk
+            ]
+            [ Html.text name ]
+        , Html.span
+            [ Ui.style "font-family" theme.fontFamily
+            , Ui.style "font-size" "11px"
+            , Ui.style "color" dsInk4
+            ]
+            [ Html.text value ]
         ]
 
 

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -1352,18 +1352,32 @@ referenceSection model rest =
         referenceHeading model.theme :: viewFramesList model rest
 
 
-{-| The "Reference" section divider — an uppercase eyebrow on a full-width rule,
-opening the supporting content below the live component.
+{-| The "Reference" section heading — a first-class peer to the Playground
+section, opening the supporting documentation below the live component. It
+mirrors the Playground header row exactly (icon + label, same size / weight /
+colour) so the two sections read at the same hierarchy level; the everything
+under it (variant charts, specimens, usage and behaviour notes) reads as its
+subsections.
 -}
 referenceHeading : Theme -> Html (Msg t e)
 referenceHeading theme =
     Html.div
-        [ Ui.style "margin-top" "48px"
-        , Ui.style "padding-bottom" "10px"
-        , Ui.style "margin-bottom" "4px"
-        , Ui.style "border-bottom" ("1px solid " ++ dsLine)
+        [ Ui.style "display" "flex"
+        , Ui.style "align-items" "center"
+        , Ui.style "gap" dsSpace2
+        , Ui.style "margin-top" "48px"
+        , Ui.style "margin-bottom" dsSpace2
+        , Ui.style "color" dsInk3
         ]
-        [ Html.span (eyebrowStyles theme) [ Html.text "Reference" ] ]
+        [ iconBox 18 (Ui.phosphorBookOpen "")
+        , Html.span
+            [ Ui.style "font-family" theme.fontFamily
+            , Ui.style "font-size" "14px"
+            , Ui.style "font-weight" "600"
+            , Ui.style "color" dsInk2
+            ]
+            [ Html.text "Reference" ]
+        ]
 
 
 viewHeading : Model t e -> Html (Msg t e)

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -679,7 +679,7 @@ shellStylesheet theme =
                 -- control elements carry `cp-control` and set only their own
                 -- typography/layout inline. Error state keeps its inline border,
                 -- which (being inline) still wins over these class rules.
-                , ".cp-control{border:1px solid " ++ theme.line ++ ";border-radius:" ++ theme.radiusSm ++ ";background:" ++ theme.surface ++ ";padding:7px 10px;transition:border-color .12s ease,box-shadow .12s ease;}"
+                , ".cp-control{box-sizing:border-box;height:36px;border:1px solid " ++ theme.line ++ ";border-radius:" ++ theme.radiusSm ++ ";background:" ++ theme.surface ++ ";padding:0 10px;line-height:normal;transition:border-color .12s ease,box-shadow .12s ease;}"
                 , ".cp-control:hover{border-color:" ++ theme.borderHover ++ ";}"
                 , ".cp-control:focus,.cp-control:focus-visible{outline:none;border-color:" ++ theme.brandBlue ++ ";box-shadow:0 0 0 3px " ++ theme.brandBlue50 ++ ";}"
                 , ".cp-control:disabled{background:" ++ theme.surfaceAlt ++ ";color:" ++ theme.ink4 ++ ";cursor:not-allowed;}"

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -1247,12 +1247,29 @@ viewContent model =
                 |> Maybe.withDefault []
     in
     Html.div
-        [ Ui.style "max-width" "1080px"
-        , Ui.style "padding" "40px 40px 0 40px"
+        [ Ui.style "padding" "40px 40px 0 40px"
         , Ui.style "display" "flex"
         , Ui.style "flex-direction" "column"
         ]
-        (viewHeading model :: viewBody model frames ++ [ bottomSpacer ])
+        (cappedColumn [ viewHeading model ]
+            :: viewBody model frames
+            ++ [ bottomSpacer ]
+        )
+
+
+{-| Wrap prose / specimen content at a readable measure (1080px). The live
+Playground callout deliberately opts out of this cap — it fills 100% of the
+available column width (respecting the column's 40px padding) in both Inspector
+states — so the cap is applied per-section here rather than on the whole column.
+-}
+cappedColumn : List (Html (Msg t e)) -> Html (Msg t e)
+cappedColumn =
+    Html.div
+        [ Ui.style "max-width" "1080px"
+        , Ui.style "width" "100%"
+        , Ui.style "display" "flex"
+        , Ui.style "flex-direction" "column"
+        ]
 
 
 {-| A real element (not just `padding-bottom`, which can read as no visible gap
@@ -1281,10 +1298,19 @@ viewBody : Model t e -> List (ProcessedFrame e t) -> List (Html (Msg t e))
 viewBody model frames =
     case splitLive frames of
         Just { live, rest } ->
-            viewPlaygroundCallout model live :: referenceSection model rest
+            -- The live callout fills the full column width; the Reference content
+            -- below it stays at the readable 1080px measure.
+            viewPlaygroundCallout model live
+                :: (case referenceSection model rest of
+                        [] ->
+                            []
+
+                        refs ->
+                            [ cappedColumn refs ]
+                   )
 
         Nothing ->
-            viewFramesList model frames
+            [ cappedColumn (viewFramesList model frames) ]
 
 
 {-| Split a page into its primary live component (the first interactive / presets

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -366,9 +366,21 @@ init theme playgrounds url =
     , inspectorOpen = True
     , activeInspector = Nothing
     , collapsedGroups = Set.empty
-    , collapsedTokens = Set.empty
+
+    -- Design-token reference groups start collapsed: they are a read-only
+    -- vocabulary, not per-component detection, so they stay out of the way
+    -- until a reader opens one.
+    , collapsedTokens = Set.fromList tokenGroupNames
     , theme = theme
     }
+
+
+{-| The design-token reference group names, in display order. Used to seed
+`collapsedTokens` (all closed by default) and to render the reference itself.
+-}
+tokenGroupNames : List String
+tokenGroupNames =
+    [ "Typography", "Colour", "Radius", "Elevation", "Spacing", "Motion" ]
 
 
 urlToPage : Url.Url -> Maybe String
@@ -628,9 +640,12 @@ shellStylesheet =
                 [ ".cp-root, .cp-root *{box-sizing:border-box;}"
                 , ".cp-nav-row{transition:background-color .12s ease,color .12s ease;}"
                 , ".cp-nav-row:hover{background:" ++ dsSurfaceAlt ++ ";}"
-                , ".cp-nav-row:focus-visible{outline:2px solid " ++ dsBrandBlue ++ ";outline-offset:-2px;}"
+                , ".cp-nav-row:focus-visible{outline:2px solid " ++ dsAccent ++ ";outline-offset:-2px;}"
                 , ".cp-nav-row.is-active{background:" ++ dsBrandBlue50 ++ ";}"
                 , ".cp-nav-row.is-active:hover{background:" ++ dsBrandBlue50 ++ ";}"
+                , ".cp-nav-icon{color:" ++ dsInk4 ++ ";transition:color .12s ease;}"
+                , ".cp-nav-row:hover .cp-nav-icon{color:" ++ dsInk3 ++ ";}"
+                , ".cp-nav-row.is-active .cp-nav-icon{color:" ++ dsAccent ++ ";}"
                 , ".cp-icon-btn{transition:background-color .12s ease,color .12s ease;}"
                 , ".cp-icon-btn:hover{background:" ++ dsSurfaceAlt ++ ";color:" ++ dsInk ++ ";}"
                 , ".cp-trigger{transition:background-color .12s ease,box-shadow .12s ease,border-color .12s ease;}"
@@ -672,7 +687,7 @@ viewSidebar model =
         [ Ui.style "width" "300px"
         , Ui.style "flex-shrink" "0"
         , Ui.style "height" "100vh"
-        , Ui.style "background" dsSurface
+        , Ui.style "background" dsSidebar
         , Ui.style "border-right" ("1px solid " ++ dsLine)
         ]
         (List.concat
@@ -712,12 +727,12 @@ viewSearchBand model =
             , Ui.style "gap" dsSpace2
             , Ui.style "height" "38px"
             , Ui.style "padding" "0 12px"
-            , Ui.style "background" dsSurfaceAlt
+            , Ui.style "background" dsSurface
             , Ui.style "border" ("1px solid " ++ dsLine)
             , Ui.style "border-radius" dsRadiusMd
             , Ui.style "color" dsInk4
             ]
-            [ iconBox 16 (Ui.lucideSearch "")
+            [ iconBox 16 (Ui.phosphorMagnifyingGlass "")
             , Html.input
                 [ Html.Attributes.placeholder "Search components…"
                 , Html.Attributes.value model.search
@@ -763,6 +778,9 @@ viewNavNode model depth (Index item) =
             isOpen =
                 not (Set.member item.id model.collapsedGroups) || model.search /= ""
 
+            containsActive =
+                List.any (nodeContainsActive model.currentPage) item.children
+
             children =
                 if isOpen then
                     List.map (viewNavNode model (depth + 1)) filteredChildren
@@ -770,23 +788,52 @@ viewNavNode model depth (Index item) =
                 else
                     []
         in
-        Ui.vStack [] (viewGroupRow model depth item isOpen :: children)
+        Ui.vStack [] (viewGroupRow model depth item isOpen containsActive :: children)
 
 
-viewGroupRow : Model t e -> Int -> { id : String, name : String, children : List Index } -> Bool -> Html (Msg t e)
-viewGroupRow model depth item isOpen =
+{-| Does this index subtree contain the currently-selected page? Used to give a
+parent category the "expanded / contains selection" treatment so the path to the
+active page reads clearly.
+-}
+nodeContainsActive : String -> Index -> Bool
+nodeContainsActive current (Index item) =
+    if List.isEmpty item.children then
+        item.id == current
+
+    else
+        List.any (nodeContainsActive current) item.children
+
+
+{-| The leading category/page glyph. Coloured by `.cp-nav-icon` (muted, brighter
+on hover, accent when the row is active) so it tracks the row state.
+-}
+navLeadingIcon : Html msg -> Html msg
+navLeadingIcon icon =
+    Html.span
+        [ Html.Attributes.class "cp-nav-icon"
+        , Ui.style "display" "inline-flex"
+        , Ui.style "flex-shrink" "0"
+        ]
+        [ iconBox 17 icon ]
+
+
+viewGroupRow : Model t e -> Int -> { id : String, name : String, children : List Index } -> Bool -> Bool -> Html (Msg t e)
+viewGroupRow model depth item isOpen containsActive =
     let
         theme =
             model.theme
 
         chevron =
-            iconBox 14
-                (if isOpen then
-                    Ui.lucideChevronDown ""
+            Html.span
+                [ Html.Attributes.class "cp-nav-icon", Ui.style "display" "inline-flex" ]
+                [ iconBox 13
+                    (if isOpen then
+                        Ui.phosphorCaretDown ""
 
-                 else
-                    Ui.lucideChevronRight ""
-                )
+                     else
+                        Ui.phosphorCaretRight ""
+                    )
+                ]
     in
     if depth == 0 then
         -- Top-level section header — an uppercase, collapsible band.
@@ -796,43 +843,65 @@ viewGroupRow model depth item isOpen =
             , Ui.style "align-items" "center"
             , Ui.style "justify-content" "space-between"
             , Ui.style "width" "100%"
-            , Ui.style "height" "32px"
-            , Ui.style "margin-top" "10px"
+            , Ui.style "height" "30px"
+            , Ui.style "margin-top" "14px"
+            , Ui.style "margin-bottom" "2px"
             , Ui.style "padding" "0 8px"
             , Ui.style "border-radius" dsRadiusMd
             , Ui.style "font-family" theme.fontFamily
             , Ui.style "font-size" "11px"
             , Ui.style "font-weight" "700"
-            , Ui.style "letter-spacing" "0.06em"
+            , Ui.style "letter-spacing" "0.07em"
             , Ui.style "text-transform" "uppercase"
             , Ui.style "color" dsInk4
             , Ui.onClick (ToggleGroup item.id)
             ]
             [ Html.span [] [ Html.text item.name ]
-            , Html.span [ Ui.style "color" dsInk4 ] [ chevron ]
+            , chevron
             ]
 
     else
-        -- Nested, expandable category (e.g. Button).
+        -- Nested, expandable category (e.g. Button). Carries a leading glyph and,
+        -- when it contains the active page, strong ink so the path stands out.
         Ui.button theme
             [ Html.Attributes.class "cp-nav-row"
             , Ui.style "display" "flex"
             , Ui.style "align-items" "center"
-            , Ui.style "gap" "6px"
+            , Ui.style "justify-content" "space-between"
+            , Ui.style "gap" "8px"
             , Ui.style "width" "100%"
             , Ui.style "height" "34px"
             , Ui.style "padding-left" (navIndent depth)
             , Ui.style "padding-right" "10px"
             , Ui.style "border-radius" dsRadiusMd
-            , Ui.style "border-left" "2px solid transparent"
+            , Ui.style "border-left" "3px solid transparent"
             , Ui.style "font-family" theme.fontFamily
             , Ui.style "font-size" "14px"
             , Ui.style "font-weight" "600"
-            , Ui.style "color" dsInk2
+            , Ui.style "color"
+                (if containsActive then
+                    dsInk
+
+                 else
+                    dsInk2
+                )
             , Ui.onClick (ToggleGroup item.id)
             ]
-            [ Html.span [ Ui.style "color" dsInk4 ] [ chevron ]
-            , Html.span [] [ Html.text item.name ]
+            [ Html.div
+                [ Ui.style "display" "flex"
+                , Ui.style "align-items" "center"
+                , Ui.style "gap" "10px"
+                , Ui.style "min-width" "0"
+                ]
+                [ navLeadingIcon (Ui.phosphorSquaresFour "")
+                , Html.span
+                    [ Ui.style "overflow" "hidden"
+                    , Ui.style "text-overflow" "ellipsis"
+                    , Ui.style "white-space" "nowrap"
+                    ]
+                    [ Html.text item.name ]
+                ]
+            , chevron
             ]
 
 
@@ -844,6 +913,16 @@ viewPageLink model depth meta =
 
         isActive =
             meta.id == model.currentPage
+
+        -- Primary nav entries (depth 1, e.g. the Design System pages) carry a
+        -- leading glyph; deeper leaf pages under a category do not, so the
+        -- category's icon stays the anchor for its group.
+        leading =
+            if depth <= 1 then
+                [ navLeadingIcon (Ui.phosphorCube "") ]
+
+            else
+                []
     in
     Ui.button theme
         [ Html.Attributes.class
@@ -858,15 +937,16 @@ viewPageLink model depth meta =
         , Ui.style "display" "flex"
         , Ui.style "align-items" "center"
         , Ui.style "justify-content" "space-between"
+        , Ui.style "gap" "8px"
         , Ui.style "width" "100%"
-        , Ui.style "height" "32px"
-        , Ui.style "padding-left" (navIndent (depth + 1))
+        , Ui.style "height" "34px"
+        , Ui.style "padding-left" (navIndent depth)
         , Ui.style "padding-right" "10px"
         , Ui.style "border-radius" dsRadiusMd
         , Ui.style "border-left"
-            ("2px solid "
+            ("3px solid "
                 ++ (if isActive then
-                        dsBrandBlue
+                        dsAccent
 
                     else
                         "transparent"
@@ -890,19 +970,28 @@ viewPageLink model depth meta =
             )
         , Ui.onClick (ViewPage meta.id)
         ]
-        [ Html.span
-            [ Ui.style "overflow" "hidden"
-            , Ui.style "text-overflow" "ellipsis"
-            , Ui.style "white-space" "nowrap"
+        [ Html.div
+            [ Ui.style "display" "flex"
+            , Ui.style "align-items" "center"
+            , Ui.style "gap" "10px"
+            , Ui.style "min-width" "0"
             ]
-            [ Html.text meta.name ]
+            (leading
+                ++ [ Html.span
+                        [ Ui.style "overflow" "hidden"
+                        , Ui.style "text-overflow" "ellipsis"
+                        , Ui.style "white-space" "nowrap"
+                        ]
+                        [ Html.text meta.name ]
+                   ]
+            )
         , if isActive then
             Html.span
                 [ Ui.style "width" "6px"
                 , Ui.style "height" "6px"
                 , Ui.style "flex-shrink" "0"
                 , Ui.style "border-radius" "50%"
-                , Ui.style "background" dsBrandBlue
+                , Ui.style "background" dsAccent
                 ]
                 []
 
@@ -960,6 +1049,7 @@ viewMainColumn model inspectables =
             [ Ui.style "flex-grow" "1"
             , Ui.style "min-height" "0"
             , Ui.style "overflow-y" "auto"
+            , Ui.style "background" dsAppBg
             ]
             [ viewContent model ]
         ]
@@ -1041,7 +1131,7 @@ viewBreadcrumbs model =
         , Ui.style "min-width" "0"
         , Ui.style "overflow" "hidden"
         ]
-        (Html.span [ Ui.style "color" dsInk4 ] [ iconBox 16 (Ui.lucideHome "") ]
+        (Html.span [ Ui.style "color" dsInk4 ] [ iconBox 16 (Ui.phosphorHouse "") ]
             :: List.concat
                 (List.indexedMap
                     (\i meta -> [ separator, crumb i meta ])
@@ -1136,7 +1226,7 @@ viewHeading model =
             , Ui.style "border-radius" dsRadiusLg
             , Ui.style "color" dsBrandBlue
             ]
-            [ iconBox 22 (Ui.lucideBox "") ]
+            [ iconBox 22 (Ui.phosphorCube "") ]
         , Ui.vStack [ Ui.style "gap" "2px", Ui.style "min-width" "0" ]
             (List.concat
                 [ if String.isEmpty subtitle then
@@ -1266,17 +1356,19 @@ playgroundCard maybeTabBar inner =
         )
 
 
-{-| A reference / specimen block (variant matrices, size charts). Uses the muted
-alt surface so it visually contrasts with the white Playground card above it.
+{-| A reference / specimen block (variant matrices, size charts). Unlike the
+Playground card — a contained live panel with border, radius and elevation — the
+specimen section reads as an open, table-like reference: no filled box, just a
+hairline rule above it for separation and room to scroll wide content. The
+contrast between the two is what tells a contained live component apart from a
+flat specimen sheet.
 -}
 specimenBlock : Html (Msg t e) -> Html (Msg t e)
 specimenBlock html =
     Html.div
-        [ Ui.style "margin-top" "16px"
-        , Ui.style "background" dsSurfaceAlt
-        , Ui.style "border" ("1px solid " ++ dsLine2)
-        , Ui.style "border-radius" dsRadiusLg
-        , Ui.style "padding" "24px"
+        [ Ui.style "margin-top" "20px"
+        , Ui.style "padding-top" "20px"
+        , Ui.style "border-top" ("1px solid " ++ dsLine2)
         , Ui.style "overflow-x" "auto"
         ]
         [ html ]
@@ -1298,7 +1390,7 @@ sectionLabel theme isFirst label =
                 )
             , Ui.style "color" dsInk3
             ]
-            [ iconBox 18 (Ui.lucideFerrisWheel "")
+            [ iconBox 18 (Ui.phosphorFlask "")
             , Html.span
                 [ Ui.style "font-family" theme.fontFamily
                 , Ui.style "font-size" "14px"
@@ -1351,14 +1443,24 @@ lookupPageName id =
 -- follow, then component settings, then the read-only design-token reference.
 
 
+dsAppBg : String
+dsAppBg =
+    "#FBFBFC"
+
+
+dsSidebar : String
+dsSidebar =
+    "#F8FAF9"
+
+
 dsSurface : String
 dsSurface =
-    "#FFFFFF"
+    "#FEFEFE"
 
 
 dsSurfaceAlt : String
 dsSurfaceAlt =
-    "#F7F8FA"
+    "#F1F0F5"
 
 
 dsLine : String
@@ -1373,7 +1475,7 @@ dsLine2 =
 
 dsInk : String
 dsInk =
-    "#202326"
+    "#0A0F22"
 
 
 dsInk2 : String
@@ -1383,12 +1485,12 @@ dsInk2 =
 
 dsInk3 : String
 dsInk3 =
-    "#5B6470"
+    "#5A5D66"
 
 
 dsInk4 : String
 dsInk4 =
-    "#8A94A0"
+    "#9DA1AC"
 
 
 dsBrandBlue : String
@@ -1396,9 +1498,14 @@ dsBrandBlue =
     "#2F7FFE"
 
 
+dsAccent : String
+dsAccent =
+    "#0E53F1"
+
+
 dsBrandBlue50 : String
 dsBrandBlue50 =
-    "#EAF2FF"
+    "#EAF1FF"
 
 
 dsSpace2 : String
@@ -1500,7 +1607,7 @@ inspectorTrigger model =
         , Html.Attributes.title "Toggle Inspector"
         , Ui.onClick ToggleInspector
         ]
-        [ iconBox 16 (Ui.lucidePanelRight ""), Html.text "Inspector" ]
+        [ iconBox 16 (Ui.phosphorSidebar ""), Html.text "Inspector" ]
 
 
 viewInspectorPanel : Model t e -> List (Inspectable t e) -> Html (Msg t e)
@@ -1561,7 +1668,7 @@ inspectorHeader theme =
             , Html.Attributes.title "Close inspector"
             , Ui.onClick ToggleInspector
             ]
-            [ iconBox 18 (Ui.lucideX "") ]
+            [ iconBox 18 (Ui.phosphorX "") ]
         ]
 
 
@@ -1582,7 +1689,7 @@ inspectorMetadata theme active =
                     , Ui.style "align-items" "center"
                     , Ui.style "gap" dsSpace2
                     ]
-                    [ Html.span [ Ui.style "color" dsBrandBlue ] [ iconBox 16 (Ui.lucideBox "") ]
+                    [ Html.span [ Ui.style "color" dsBrandBlue ] [ iconBox 16 (Ui.phosphorCube "") ]
                     , Html.span
                         [ Ui.style "font-family" theme.fontFamily
                         , Ui.style "font-size" "14px"
@@ -1767,10 +1874,10 @@ tokenGroup model groupName rows =
             , Html.span [ Ui.style "color" dsInk4 ]
                 [ iconBox 14
                     (if collapsed then
-                        Ui.lucideChevronRight ""
+                        Ui.phosphorCaretRight ""
 
                      else
-                        Ui.lucideChevronDown ""
+                        Ui.phosphorCaretDown ""
                     )
                 ]
             ]

--- a/src/Component/Application.elm
+++ b/src/Component/Application.elm
@@ -3,6 +3,7 @@ module Component.Application exposing
     , ComponentInstance, ComponentUpdate, Index, Library_, Playground, Ref, Type
     , element, init, update, view, toUrl
     , fromUpdate, renderPortal
+    , initWith
     )
 
 {-| Application runner for the Component Playground.
@@ -34,6 +35,7 @@ application using `init`, `update`, and `view`.
 
 import Browser
 import Component.Application.Theme exposing (Theme)
+import Component.ControlRenderers as ControlRenderers exposing (ControlRenderers)
 import Component.Internal as Internal
     exposing
         ( ComponentE
@@ -152,8 +154,8 @@ type alias Type t =
 -- PROCESSING
 
 
-extractLibrary : List (Playground e t) -> Internal.Library_ e t
-extractLibrary playgrounds =
+extractLibrary : ControlRenderers (List ( Ref, Type t )) -> List (Playground e t) -> Internal.Library_ e t
+extractLibrary renderers playgrounds =
     let
         defs =
             extractDefs playgrounds
@@ -164,6 +166,7 @@ extractLibrary playgrounds =
     { index = List.map (\d -> { id = d.id, name = d.name }) defs
     , groups = List.filterMap extractGroup playgrounds
     , lookupDef = \id -> Dict.get id defDict
+    , renderers = renderers
     }
 
 
@@ -335,9 +338,18 @@ element theme playgrounds url =
 
 init : Theme -> List (Playground e t) -> Maybe Url.Url -> Model t e
 init theme playgrounds url =
+    initWith (ControlRenderers.default theme) theme playgrounds url
+
+
+{-| Like `init`, but the host supplies its own Inspector control renderers (see
+`Component.ControlRenderers`) so the Inspector is configured with the host's own
+production controls. `init` uses the library's fallback renderers.
+-}
+initWith : ControlRenderers (List ( Ref, Type t )) -> Theme -> List (Playground e t) -> Maybe Url.Url -> Model t e
+initWith renderers theme playgrounds url =
     let
         library =
-            extractLibrary playgrounds
+            extractLibrary renderers playgrounds
 
         idx =
             toIndex Nothing playgrounds

--- a/src/Component/Application/Theme.elm
+++ b/src/Component/Application/Theme.elm
@@ -126,27 +126,26 @@ defaultSidebarHeader =
             , Attributes.style "height" "24px"
             , Attributes.style "flex-shrink" "0"
             ]
-            [ lucideBlocksSvg ]
+            [ phosphorSquaresFourSvg ]
         , Html.span [] [ Html.text "Component Playground" ]
         ]
 
 
-lucideBlocksSvg : Html Never
-lucideBlocksSvg =
+{-| Phosphor `squares-four` — the default playground-chrome logo glyph, used only
+when the host application does not supply its own `sidebarHeader` (e.g.
+Planwisely substitutes its product logo here). A filled 256×256 glyph painted in
+`currentColor`.
+-}
+phosphorSquaresFourSvg : Html Never
+phosphorSquaresFourSvg =
     Svg.svg
-        [ SvgAttrs.viewBox "0 0 24 24"
-        , SvgAttrs.fill "none"
+        [ SvgAttrs.viewBox "0 0 256 256"
+        , SvgAttrs.fill "currentColor"
         , SvgAttrs.width "100%"
         , SvgAttrs.height "100%"
         ]
         [ Svg.path
-            [ SvgAttrs.d "M10 21V8C10 7.73478 9.89464 7.48043 9.70711 7.29289C9.51957 7.10536 9.26522 7 9 7H4C3.73478 7 3.48043 7.10536 3.29289 7.29289C3.10536 7.48043 3 7.73478 3 8V20C3 20.2652 3.10536 20.5196 3.29289 20.7071C3.48043 20.8946 3.73478 21 4 21H16C16.2652 21 16.5196 20.8946 16.7071 20.7071C16.8946 20.5196 17 20.2652 17 20V15C17 14.7348 16.8946 14.4804 16.7071 14.2929C16.5196 14.1054 16.2652 14 16 14H3M15 3H20C20.5523 3 21 3.44772 21 4V9C21 9.55228 20.5523 10 20 10H15C14.4477 10 14 9.55228 14 9V4C14 3.44772 14.4477 3 15 3Z"
-            , SvgAttrs.stroke "currentColor"
-            , SvgAttrs.strokeWidth "2"
-            , SvgAttrs.strokeLinecap "round"
-            , SvgAttrs.strokeLinejoin "round"
-            , Attributes.attribute "vector-effect" "non-scaling-stroke"
-            ]
+            [ SvgAttrs.d "M104,40H56A16,16,0,0,0,40,56v48a16,16,0,0,0,16,16h48a16,16,0,0,0,16-16V56A16,16,0,0,0,104,40Zm0,64H56V56h48v48Zm96-64H152a16,16,0,0,0-16,16v48a16,16,0,0,0,16,16h48a16,16,0,0,0,16-16V56A16,16,0,0,0,200,40Zm0,64H152V56h48v48Zm-96,32H56a16,16,0,0,0-16,16v48a16,16,0,0,0,16,16h48a16,16,0,0,0,16-16V152A16,16,0,0,0,104,136Zm0,64H56V152h48v48Zm96-64H152a16,16,0,0,0-16,16v48a16,16,0,0,0,16,16h48a16,16,0,0,0,16-16V152A16,16,0,0,0,200,136Zm0,64H152V152h48v48Z" ]
             []
         ]
 

--- a/src/Component/Application/Theme.elm
+++ b/src/Component/Application/Theme.elm
@@ -87,6 +87,37 @@ type alias Theme =
     -- Controls
     , errorColor : String
 
+    -- Design tokens (Inspector skin)
+    --
+    -- The palette the application chrome and the Inspector controls are skinned
+    -- from. These are host-overridable so a consuming app (e.g. Planwisely) can
+    -- map every value to its own design-system tokens (`--pw-*`) without the
+    -- library carrying app-specific constants. `default` ships a neutral light
+    -- palette.
+    , appBg : String
+    , sidebar : String
+    , surface : String
+    , surfaceAlt : String
+    , line : String
+    , line2 : String
+    , borderHover : String
+    , ink : String
+    , ink2 : String
+    , ink3 : String
+    , ink4 : String
+    , brandBlue : String
+    , accent : String
+    , brandBlue50 : String
+    , space2 : String
+    , space3 : String
+    , space4 : String
+    , radiusSm : String
+    , radiusMd : String
+    , radiusLg : String
+    , shadow1 : String
+    , shadow2 : String
+    , shadow4 : String
+
     -- Sidebar slots
     , sidebarHeader : Html Never
     , sidebarFooter : Maybe (Html Never)
@@ -109,6 +140,29 @@ default =
     , subHeadingFontSize = "16px"
     , subHeadingFontWeight = "400"
     , errorColor = "#f66"
+    , appBg = "#FBFBFC"
+    , sidebar = "#F8FAF9"
+    , surface = "#FEFEFE"
+    , surfaceAlt = "#F1F0F5"
+    , line = "#E5E8EC"
+    , line2 = "#EEF0F3"
+    , borderHover = "#B8C0CC"
+    , ink = "#0A0F22"
+    , ink2 = "#3A4149"
+    , ink3 = "#5A5D66"
+    , ink4 = "#9DA1AC"
+    , brandBlue = "#2F7FFE"
+    , accent = "#0E53F1"
+    , brandBlue50 = "#EAF1FF"
+    , space2 = "8px"
+    , space3 = "12px"
+    , space4 = "16px"
+    , radiusSm = "4px"
+    , radiusMd = "8px"
+    , radiusLg = "10px"
+    , shadow1 = "0 1px 2px rgba(16,24,40,0.05)"
+    , shadow2 = "0 2px 4px rgba(16,24,40,0.06), 0 4px 8px rgba(16,24,40,0.04)"
+    , shadow4 = "0 8px 16px rgba(16,24,40,0.08), 0 24px 48px rgba(16,24,40,0.12)"
     , sidebarHeader = defaultSidebarHeader
     , sidebarFooter = Nothing
     }

--- a/src/Component/Control.elm
+++ b/src/Component/Control.elm
@@ -528,9 +528,14 @@ fromOptions desc first rest =
         presets =
             first :: rest
 
-        inner : Ref -> Internal.ControlI_ e t a a a
-        inner ref =
+        inner : Internal.Library e t -> Ref -> Internal.ControlI_ e t a a a
+        inner lib ref =
             let
+                renderers =
+                    case lib of
+                        Internal.Library _ l ->
+                            l.renderers
+
                 values =
                     Array.fromList (List.map Tuple.first presets)
 
@@ -557,9 +562,9 @@ fromOptions desc first rest =
                         |> Maybe.andThen Type.intValue
                         |> Maybe.orElseLazy (\() -> findIndex default)
 
-                controls theme label default lookup =
-                    Ui.select theme
-                        { msg =
+                controls _ label default lookup =
+                    renderers.select
+                        { onChange =
                             String.toInt
                                 >> Maybe.map (\i -> [ ( ref, Type.IntValue i ) ])
                                 >> Maybe.withDefault []
@@ -591,7 +596,7 @@ fromOptions desc first rest =
             , description = Just desc
             }
     in
-    Control <| \_ -> State.map inner Ref.take
+    Control <| \lib -> State.map (inner lib) Ref.take
 
 
 {-| Control backed by a named lookup list. The stored value is the key string;

--- a/src/Component/ControlRenderers.elm
+++ b/src/Component/ControlRenderers.elm
@@ -1,0 +1,62 @@
+module Component.ControlRenderers exposing (ControlRenderers, SelectConfig, default)
+
+{-| Host-injectable renderers for the Inspector's controls.
+
+The playground is "just another consumer" of a design system: the controls that
+configure a component should be able to be the host's own production controls.
+This module defines the generic interface for that injection — the library
+provides a fallback built from its own primitives, and a consuming application
+(e.g. Planwisely) may supply its own renderers that adapt the control data into
+its real components, **without the library depending on the host**.
+
+This is a deliberately narrow proof: only the `select` control is injectable so
+far. The data each renderer receives is exactly what the library already has at
+the control site, so a host renderer is a pure adapter.
+
+@docs ControlRenderers, SelectConfig, default
+
+-}
+
+import Component.Application.Theme exposing (Theme)
+import Component.Ui as Ui
+import Html exposing (Html)
+
+
+{-| The configuration the library hands a `select` renderer: the field id and
+label, the current value, the available options, and the change handler. `msg`
+is the control-update message — the renderer is fully polymorphic in it, so a
+host renderer simply threads `onChange` into its own component.
+-}
+type alias SelectConfig msg =
+    { id : String
+    , label : String
+    , value : String
+    , options : List { label : String, value : String }
+    , onChange : String -> msg
+    }
+
+
+{-| The set of host-injectable control renderers. Narrow by design — extend with
+`textField`, `toggle`, … as the proof graduates to a migration.
+-}
+type alias ControlRenderers msg =
+    { select : SelectConfig msg -> Html msg
+    }
+
+
+{-| The library's fallback renderers, built from its own `Component.Ui`
+primitives. Used when a host supplies none, so the library still works
+standalone.
+-}
+default : Theme -> ControlRenderers msg
+default theme =
+    { select =
+        \c ->
+            Ui.select theme
+                { id = c.id
+                , options = c.options
+                , label = c.label
+                , value = c.value
+                , msg = c.onChange
+                }
+    }

--- a/src/Component/Frame.elm
+++ b/src/Component/Frame.elm
@@ -272,6 +272,7 @@ makeFactory :
         , controls : Control e t state value
         , view : state -> value -> (state -> Update t) -> Internal.View (Update t)
         , presets : List (Internal.Preset t state)
+        , tokens : List Internal.TokenGroup
     }
     -> Internal.Library e t
     -> State Ref (ComponentE e t)
@@ -293,7 +294,7 @@ makeFactory c lib =
 
 buildComponentE :
     ComponentInstance
-    -> { a | view : state -> value -> (state -> Update t) -> Internal.View (Update t), presets : List (Internal.Preset t state) }
+    -> { a | view : state -> value -> (state -> Update t) -> Internal.View (Update t), presets : List (Internal.Preset t state), tokens : List Internal.TokenGroup }
     -> (Internal.Library e t -> State Ref (Internal.ControlI_ e t state state value))
     -> Internal.Library e t
     -> State Ref (ComponentE e t)
@@ -301,7 +302,7 @@ buildComponentE instance c controlsF lib =
     case c.presets of
         [] ->
             controlsF lib
-                |> State.map (\b -> makeComponentE instance c.view [] Nothing b)
+                |> State.map (\b -> makeComponentE instance c.view c.tokens [] Nothing b)
 
         _ ->
             controlsF lib
@@ -310,7 +311,7 @@ buildComponentE instance c controlsF lib =
                         Ref.take
                             |> State.map
                                 (\presetRef ->
-                                    makeComponentE instance c.view c.presets (Just presetRef) b
+                                    makeComponentE instance c.view c.tokens c.presets (Just presetRef) b
                                 )
                     )
 
@@ -318,11 +319,12 @@ buildComponentE instance c controlsF lib =
 makeComponentE :
     Internal.ComponentInstance
     -> (state -> value -> (state -> Update t) -> Internal.View (Update t))
+    -> List Internal.TokenGroup
     -> List (Internal.Preset t state)
     -> Maybe Ref
     -> Internal.ControlI_ e t state state value
     -> ComponentE e t
-makeComponentE instance componentView presetList maybePresetRef rawB =
+makeComponentE instance componentView tokens presetList maybePresetRef rawB =
     let
         b =
             case presetList of
@@ -388,6 +390,7 @@ makeComponentE instance componentView presetList maybePresetRef rawB =
     , innerControls = innerControls
     , update = update
     , presets = maybeInfo
+    , tokens = tokens
     }
 
 

--- a/src/Component/Internal.elm
+++ b/src/Component/Internal.elm
@@ -14,6 +14,8 @@ module Component.Internal exposing
     , Playground(..)
     , Preset
     , PresetsInfo
+    , Token
+    , TokenGroup
     , Update(..)
     , View
     )
@@ -30,6 +32,26 @@ import State exposing (State)
 -}
 type alias Lookup t =
     Ref -> Maybe (Type t)
+
+
+
+-- DESIGN-TOKEN METADATA
+
+
+{-| A single design token a component consumes: its name (e.g. `pw-ink`) and
+its resolved value (e.g. `#0A0F22`).
+-}
+type alias Token =
+    { name : String, value : String }
+
+
+{-| A category of design tokens a component consumes (e.g. Colour, Motion),
+with the specific tokens within it. Attached to a component via
+`Component.withTokens`; the Inspector renders exactly these — and only these —
+so the token reference reflects the selected component.
+-}
+type alias TokenGroup =
+    { category : String, tokens : List Token }
 
 
 
@@ -119,6 +141,7 @@ type alias ComponentE e t =
     , innerControls : Theme -> Lookup t -> List (Html (Update t))
     , update : Lookup t -> Lookup t -> ( List ( Ref, Type t ), List e )
     , presets : Maybe (PresetsInfo t)
+    , tokens : List TokenGroup
     }
 
 
@@ -171,6 +194,7 @@ type Component_ e t i m msg
         , controls : Control e t i m
         , view : i -> m -> (i -> msg) -> View msg
         , presets : List (Preset t i)
+        , tokens : List TokenGroup
         }
 
 

--- a/src/Component/Internal.elm
+++ b/src/Component/Internal.elm
@@ -21,6 +21,7 @@ module Component.Internal exposing
     )
 
 import Component.Application.Theme exposing (Theme)
+import Component.ControlRenderers exposing (ControlRenderers)
 import Component.Ref exposing (Ref)
 import Component.Type exposing (Type)
 import Dict exposing (Dict)
@@ -240,6 +241,12 @@ type alias Library_ e t =
     { index : List { id : String, name : String }
     , groups : List { name : String, pages : List { id : String, name : String } }
     , lookupDef : String -> Maybe (Library e t -> State Ref (ComponentE e t))
+
+    -- Host-injectable control renderers (see Component.ControlRenderers). The
+    -- select control consults these so a consuming app can render the Inspector
+    -- with its own production controls; `Component.ControlRenderers.default`
+    -- provides the standalone fallback.
+    , renderers : ControlRenderers (List ( Ref, Type t ))
     }
 
 

--- a/src/Component/Ui.elm
+++ b/src/Component/Ui.elm
@@ -5,16 +5,17 @@ module Component.Ui exposing
     , hStack
     , headingStyles
     , labelStyles
-    , lucideBox
-    , lucideChevronDown
-    , lucideChevronRight
-    , lucideFerrisWheel
-    , lucideHome
-    , lucidePanelRight
-    , lucideSearch
-    , lucideSettings2
-    , lucideX
     , onClick
+    , phosphorCaretDown
+    , phosphorCaretRight
+    , phosphorCube
+    , phosphorFlask
+    , phosphorHouse
+    , phosphorMagnifyingGlass
+    , phosphorSidebar
+    , phosphorSlidersHorizontal
+    , phosphorSquaresFour
+    , phosphorX
     , select
     , style
     , subHeadingStyles
@@ -272,146 +273,103 @@ disableAutocomplete =
     Attributes.property "autocomplete" (Encode.string "off")
 
 
-{-| search.svg
+{-| Shared frame for the Phosphor icons below. Phosphor "regular" glyphs are
+filled shapes on a 256×256 viewBox, painted in `currentColor` so each icon
+inherits the surrounding text colour. Each icon supplies its own path `d`
+strings; everything else is uniform.
+
+These are the generic playground-chrome icons (search, carets, breadcrumb home,
+Inspector affordances, section glyphs). Product / brand icons are supplied by
+the host application and are never sourced from here.
+
 -}
-lucideSearch : String -> Svg msg
-lucideSearch class =
+phosphorIcon : String -> List String -> Svg msg
+phosphorIcon class ds =
     Svg.svg
         [ Attrs.class class
-        , Attrs.viewBox "0 0 24 24"
-        , Attrs.fill "none"
+        , Attrs.viewBox "0 0 256 256"
+        , Attrs.fill "currentColor"
         , Attrs.width "100%"
         , Attrs.height "100%"
         ]
-        [ Svg.path
-            [ Attrs.d "M21.0002 21L16.7002 16.7M19 11C19 15.4183 15.4183 19 11 19C6.58172 19 3 15.4183 3 11C3 6.58172 6.58172 3 11 3C15.4183 3 19 6.58172 19 11Z"
-            , Attrs.stroke "currentColor"
-            , Attrs.strokeWidth "2"
-            , Attrs.strokeLinecap "round"
-            , Attrs.strokeLinejoin "round"
-            , Attributes.attribute "vector-effect" "non-scaling-stroke"
-            ]
-            []
-        ]
+        (List.map (\d -> Svg.path [ Attrs.d d ] []) ds)
 
 
-{-| settings-2.svg
+{-| magnifying-glass — the sidebar search affordance.
 -}
-lucideSettings2 : String -> Svg msg
-lucideSettings2 class =
-    Svg.svg
-        [ Attrs.class class
-        , Attrs.viewBox "0 0 24 24"
-        , Attrs.fill "none"
-        , Attrs.width "100%"
-        , Attrs.height "100%"
-        ]
-        [ Svg.path
-            [ Attrs.d "M20 7H11M14 17H5M14 17C14 18.6569 15.3431 20 17 20C18.6569 20 20 18.6569 20 17C20 15.3431 18.6569 14 17 14C15.3431 14 14 15.3431 14 17ZM10 7C10 8.65685 8.65685 10 7 10C5.34315 10 4 8.65685 4 7C4 5.34315 5.34315 4 7 4C8.65685 4 10 5.34315 10 7Z"
-            , Attrs.stroke "currentColor"
-            , Attrs.strokeWidth "2"
-            , Attrs.strokeLinecap "round"
-            , Attrs.strokeLinejoin "round"
-            , Attributes.attribute "vector-effect" "non-scaling-stroke"
-            ]
-            []
-        ]
+phosphorMagnifyingGlass : String -> Svg msg
+phosphorMagnifyingGlass class =
+    phosphorIcon class
+        [ "M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z" ]
 
 
-{-| Shared stroked-icon frame for the lucide icons below. Each icon supplies its
-own path `d` strings; everything else (24×24 viewBox, round caps, 2px
-non-scaling stroke in `currentColor`) is uniform with the icons above.
+{-| caret-down — expanded sidebar group / open token group affordance.
 -}
-lucideIcon : String -> List String -> Svg msg
-lucideIcon class ds =
-    Svg.svg
-        [ Attrs.class class
-        , Attrs.viewBox "0 0 24 24"
-        , Attrs.fill "none"
-        , Attrs.width "100%"
-        , Attrs.height "100%"
-        ]
-        (List.map
-            (\d ->
-                Svg.path
-                    [ Attrs.d d
-                    , Attrs.stroke "currentColor"
-                    , Attrs.strokeWidth "2"
-                    , Attrs.strokeLinecap "round"
-                    , Attrs.strokeLinejoin "round"
-                    , Attributes.attribute "vector-effect" "non-scaling-stroke"
-                    ]
-                    []
-            )
-            ds
-        )
+phosphorCaretDown : String -> Svg msg
+phosphorCaretDown class =
+    phosphorIcon class
+        [ "M213.66,101.66l-80,80a8,8,0,0,1-11.32,0l-80-80A8,8,0,0,1,53.66,90.34L128,164.69l74.34-74.35a8,8,0,0,1,11.32,11.32Z" ]
 
 
-{-| panel-right.svg — a properties/side-panel glyph. Used for the Inspector
-trigger in the top ribbon.
+{-| caret-right — collapsed sidebar group / closed token group affordance.
 -}
-lucidePanelRight : String -> Svg msg
-lucidePanelRight class =
-    lucideIcon class
-        [ "M3 5C3 3.89543 3.89543 3 5 3H19C20.1046 3 21 3.89543 21 5V19C21 20.1046 20.1046 21 19 21H5C3.89543 21 3 20.1046 3 19V5Z"
-        , "M15 3V21"
-        ]
+phosphorCaretRight : String -> Svg msg
+phosphorCaretRight class =
+    phosphorIcon class
+        [ "M181.66,133.66l-80,80a8,8,0,0,1-11.32-11.32L164.69,128,90.34,53.66a8,8,0,0,1,11.32-11.32l80,80A8,8,0,0,1,181.66,133.66Z" ]
 
 
-{-| ferris-wheel.svg — labels the live Playground section.
+{-| x — Inspector close button.
 -}
-lucideFerrisWheel : String -> Svg msg
-lucideFerrisWheel class =
-    lucideIcon class
-        [ "M12 14C13.1046 14 14 13.1046 14 12C14 10.8954 13.1046 10 12 10C10.8954 10 10 10.8954 10 12C10 13.1046 10.8954 14 12 14Z"
-        , "M12 2V6"
-        , "M6.8 15L3.3 17"
-        , "M20.7 7L17.2 9"
-        , "M6.8 9L3.3 7"
-        , "M20.7 17L17.2 15"
-        , "M9 22L12 14L15 22"
-        , "M8 22H16"
-        , "M18 18.7A9 9 0 1 0 6 18.7"
-        ]
+phosphorX : String -> Svg msg
+phosphorX class =
+    phosphorIcon class
+        [ "M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z" ]
 
 
-{-| chevron-right.svg — collapsed sidebar group affordance.
+{-| house — breadcrumb root.
 -}
-lucideChevronRight : String -> Svg msg
-lucideChevronRight class =
-    lucideIcon class [ "M9 18L15 12L9 6" ]
+phosphorHouse : String -> Svg msg
+phosphorHouse class =
+    phosphorIcon class
+        [ "M219.31,108.68l-80-80a16,16,0,0,0-22.62,0l-80,80A15.87,15.87,0,0,0,32,120v96a8,8,0,0,0,8,8h64a8,8,0,0,0,8-8V160h32v56a8,8,0,0,0,8,8h64a8,8,0,0,0,8-8V120A15.87,15.87,0,0,0,219.31,108.68ZM208,208H160V152a8,8,0,0,0-8-8H104a8,8,0,0,0-8,8v56H48V120l80-80,80,80Z" ]
 
 
-{-| chevron-down.svg — expanded sidebar group / open token group affordance.
+{-| cube — neutral component glyph (page-heading chip, Inspector metadata).
 -}
-lucideChevronDown : String -> Svg msg
-lucideChevronDown class =
-    lucideIcon class [ "M6 9L12 15L18 9" ]
+phosphorCube : String -> Svg msg
+phosphorCube class =
+    phosphorIcon class
+        [ "M223.68,66.15,135.68,18h0a15.88,15.88,0,0,0-15.36,0l-88,48.17a16,16,0,0,0-8.32,14v95.64a16,16,0,0,0,8.32,14l88,48.17a15.88,15.88,0,0,0,15.36,0l88-48.17a16,16,0,0,0,8.32-14V80.18A16,16,0,0,0,223.68,66.15ZM128,32h0l80.34,44L128,120,47.66,76ZM40,90l80,43.78v85.79L40,175.82Zm96,129.57V133.82L216,90v85.78Z" ]
 
 
-{-| x.svg — Inspector close button.
+{-| sidebar-simple — the Inspector trigger in the top ribbon.
 -}
-lucideX : String -> Svg msg
-lucideX class =
-    lucideIcon class [ "M18 6L6 18", "M6 6L18 18" ]
+phosphorSidebar : String -> Svg msg
+phosphorSidebar class =
+    phosphorIcon class
+        [ "M216,40H40A16,16,0,0,0,24,56V200a16,16,0,0,0,16,16H216a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40ZM40,56H80V200H40ZM216,200H96V56H216V200Z" ]
 
 
-{-| home.svg — breadcrumb root.
+{-| squares-four — sidebar category / navigation-group glyph.
 -}
-lucideHome : String -> Svg msg
-lucideHome class =
-    lucideIcon class
-        [ "M3 9L12 2L21 9V20C21 21.1046 20.1046 22 19 22H5C3.89543 22 3 21.1046 3 20V9Z"
-        , "M9 22V12H15V22"
-        ]
+phosphorSquaresFour : String -> Svg msg
+phosphorSquaresFour class =
+    phosphorIcon class
+        [ "M104,40H56A16,16,0,0,0,40,56v48a16,16,0,0,0,16,16h48a16,16,0,0,0,16-16V56A16,16,0,0,0,104,40Zm0,64H56V56h48v48Zm96-64H152a16,16,0,0,0-16,16v48a16,16,0,0,0,16,16h48a16,16,0,0,0,16-16V56A16,16,0,0,0,200,40Zm0,64H152V56h48v48Zm-96,32H56a16,16,0,0,0-16,16v48a16,16,0,0,0,16,16h48a16,16,0,0,0,16-16V152A16,16,0,0,0,104,136Zm0,64H56V152h48v48Zm96-64H152a16,16,0,0,0-16,16v48a16,16,0,0,0,16,16h48a16,16,0,0,0,16-16V152A16,16,0,0,0,200,136Zm0,64H152V152h48v48Z" ]
 
 
-{-| box.svg — neutral component glyph for the page-heading chip.
+{-| flask — labels the live Playground section.
 -}
-lucideBox : String -> Svg msg
-lucideBox class =
-    lucideIcon class
-        [ "M21 8C21 7.27331 20.6 6.605 19.96 6.27L13.46 2.78C12.55 2.29 11.45 2.29 10.54 2.78L4.04 6.27C3.4 6.605 3 7.27331 3 8V16C3 16.7267 3.4 17.395 4.04 17.73L10.54 21.22C11.45 21.71 12.55 21.71 13.46 21.22L19.96 17.73C20.6 17.395 21 16.7267 21 16V8Z"
-        , "M3.3 7L12 12L20.7 7"
-        , "M12 22V12"
-        ]
+phosphorFlask : String -> Svg msg
+phosphorFlask class =
+    phosphorIcon class
+        [ "M221.69,199.77,160,96.92V40h8a8,8,0,0,0,0-16H88a8,8,0,0,0,0,16h8V96.92L34.31,199.77A16,16,0,0,0,48,224H208a16,16,0,0,0,13.72-24.23ZM110.86,103.25A7.93,7.93,0,0,0,112,99.14V40h32V99.14a7.93,7.93,0,0,0,1.14,4.11L183.36,167c-12,2.37-29.07,1.37-51.75-10.11-15.91-8.05-31.05-12.32-45.22-12.81ZM48,208l28.54-47.58c14.25-1.74,30.31,1.85,47.82,10.72,19,9.61,35,12.88,48,12.88a69.89,69.89,0,0,0,19.55-2.7L208,208Z" ]
+
+
+{-| sliders-horizontal — the component-settings glyph in the Inspector.
+-}
+phosphorSlidersHorizontal : String -> Svg msg
+phosphorSlidersHorizontal class =
+    phosphorIcon class
+        [ "M40,88H73a32,32,0,0,0,62,0h81a8,8,0,0,0,0-16H135a32,32,0,0,0-62,0H40a8,8,0,0,0,0,16Zm64-24A16,16,0,1,1,88,80,16,16,0,0,1,104,64ZM216,168H199a32,32,0,0,0-62,0H40a8,8,0,0,0,0,16h97a32,32,0,0,0,62,0h17a8,8,0,0,0,0-16Zm-48,24a16,16,0,1,1,16-16A16,16,0,0,1,168,192Z" ]

--- a/src/Component/Ui.elm
+++ b/src/Component/Ui.elm
@@ -5,8 +5,15 @@ module Component.Ui exposing
     , hStack
     , headingStyles
     , labelStyles
+    , lucideBox
+    , lucideChevronDown
+    , lucideChevronRight
+    , lucideFerrisWheel
+    , lucideHome
+    , lucidePanelRight
     , lucideSearch
     , lucideSettings2
+    , lucideX
     , onClick
     , select
     , style
@@ -308,4 +315,103 @@ lucideSettings2 class =
             , Attributes.attribute "vector-effect" "non-scaling-stroke"
             ]
             []
+        ]
+
+
+{-| Shared stroked-icon frame for the lucide icons below. Each icon supplies its
+own path `d` strings; everything else (24×24 viewBox, round caps, 2px
+non-scaling stroke in `currentColor`) is uniform with the icons above.
+-}
+lucideIcon : String -> List String -> Svg msg
+lucideIcon class ds =
+    Svg.svg
+        [ Attrs.class class
+        , Attrs.viewBox "0 0 24 24"
+        , Attrs.fill "none"
+        , Attrs.width "100%"
+        , Attrs.height "100%"
+        ]
+        (List.map
+            (\d ->
+                Svg.path
+                    [ Attrs.d d
+                    , Attrs.stroke "currentColor"
+                    , Attrs.strokeWidth "2"
+                    , Attrs.strokeLinecap "round"
+                    , Attrs.strokeLinejoin "round"
+                    , Attributes.attribute "vector-effect" "non-scaling-stroke"
+                    ]
+                    []
+            )
+            ds
+        )
+
+
+{-| panel-right.svg — a properties/side-panel glyph. Used for the Inspector
+trigger in the top ribbon.
+-}
+lucidePanelRight : String -> Svg msg
+lucidePanelRight class =
+    lucideIcon class
+        [ "M3 5C3 3.89543 3.89543 3 5 3H19C20.1046 3 21 3.89543 21 5V19C21 20.1046 20.1046 21 19 21H5C3.89543 21 3 20.1046 3 19V5Z"
+        , "M15 3V21"
+        ]
+
+
+{-| ferris-wheel.svg — labels the live Playground section.
+-}
+lucideFerrisWheel : String -> Svg msg
+lucideFerrisWheel class =
+    lucideIcon class
+        [ "M12 14C13.1046 14 14 13.1046 14 12C14 10.8954 13.1046 10 12 10C10.8954 10 10 10.8954 10 12C10 13.1046 10.8954 14 12 14Z"
+        , "M12 2V6"
+        , "M6.8 15L3.3 17"
+        , "M20.7 7L17.2 9"
+        , "M6.8 9L3.3 7"
+        , "M20.7 17L17.2 15"
+        , "M9 22L12 14L15 22"
+        , "M8 22H16"
+        , "M18 18.7A9 9 0 1 0 6 18.7"
+        ]
+
+
+{-| chevron-right.svg — collapsed sidebar group affordance.
+-}
+lucideChevronRight : String -> Svg msg
+lucideChevronRight class =
+    lucideIcon class [ "M9 18L15 12L9 6" ]
+
+
+{-| chevron-down.svg — expanded sidebar group / open token group affordance.
+-}
+lucideChevronDown : String -> Svg msg
+lucideChevronDown class =
+    lucideIcon class [ "M6 9L12 15L18 9" ]
+
+
+{-| x.svg — Inspector close button.
+-}
+lucideX : String -> Svg msg
+lucideX class =
+    lucideIcon class [ "M18 6L6 18", "M6 6L18 18" ]
+
+
+{-| home.svg — breadcrumb root.
+-}
+lucideHome : String -> Svg msg
+lucideHome class =
+    lucideIcon class
+        [ "M3 9L12 2L21 9V20C21 21.1046 20.1046 22 19 22H5C3.89543 22 3 21.1046 3 20V9Z"
+        , "M9 22V12H15V22"
+        ]
+
+
+{-| box.svg — neutral component glyph for the page-heading chip.
+-}
+lucideBox : String -> Svg msg
+lucideBox class =
+    lucideIcon class
+        [ "M21 8C21 7.27331 20.6 6.605 19.96 6.27L13.46 2.78C12.55 2.29 11.45 2.29 10.54 2.78L4.04 6.27C3.4 6.605 3 7.27331 3 8V16C3 16.7267 3.4 17.395 4.04 17.73L10.54 21.22C11.45 21.71 12.55 21.71 13.46 21.22L19.96 17.73C20.6 17.395 21 16.7267 21 16V8Z"
+        , "M3.3 7L12 12L20.7 7"
+        , "M12 22V12"
         ]

--- a/src/Component/Ui.elm
+++ b/src/Component/Ui.elm
@@ -186,7 +186,6 @@ textField theme c =
                       , Attributes.id c.id
                       , Attributes.value c.value
                       , Events.onInput c.msg
-                      , style "margin-left" "8px"
                       , style "flex-shrink" "0"
                       , controlWidth
                       ]
@@ -197,13 +196,13 @@ textField theme c =
                 []
     in
     vStack
-        [ style "align-items" "end"
-        , style "background-color" theme.backgroundColor
+        [ style "width" "100%"
+        , style "gap" "4px"
         ]
         (hStack
-            [ style "align-items" "baseline"
-            , style "justify-content" "space-between"
+            [ style "align-items" "center"
             , style "width" "100%"
+            , style "gap" "12px"
             ]
             [ label, input ]
             :: errorBit
@@ -240,7 +239,7 @@ select theme c =
             Html.select
                 (inputStyles theme
                     ++ [ Attributes.id c.id
-                       , style "margin-left" "8px"
+                       , style "flex-shrink" "0"
                        , Events.onInput c.msg
                        , Attributes.value value
                        , controlWidth

--- a/src/Component/Ui.elm
+++ b/src/Component/Ui.elm
@@ -6,6 +6,7 @@ module Component.Ui exposing
     , headingStyles
     , labelStyles
     , onClick
+    , phosphorBookOpen
     , phosphorCaretDown
     , phosphorCaretRight
     , phosphorCube
@@ -365,6 +366,14 @@ phosphorFlask : String -> Svg msg
 phosphorFlask class =
     phosphorIcon class
         [ "M221.69,199.77,160,96.92V40h8a8,8,0,0,0,0-16H88a8,8,0,0,0,0,16h8V96.92L34.31,199.77A16,16,0,0,0,48,224H208a16,16,0,0,0,13.72-24.23ZM110.86,103.25A7.93,7.93,0,0,0,112,99.14V40h32V99.14a7.93,7.93,0,0,0,1.14,4.11L183.36,167c-12,2.37-29.07,1.37-51.75-10.11-15.91-8.05-31.05-12.32-45.22-12.81ZM48,208l28.54-47.58c14.25-1.74,30.31,1.85,47.82,10.72,19,9.61,35,12.88,48,12.88a69.89,69.89,0,0,0,19.55-2.7L208,208Z" ]
+
+
+{-| book-open — labels the Reference section (peer to the Playground flask).
+-}
+phosphorBookOpen : String -> Svg msg
+phosphorBookOpen class =
+    phosphorIcon class
+        [ "M232,48H160a40,40,0,0,0-32,16A40,40,0,0,0,96,48H24A16,16,0,0,0,8,64V192a16,16,0,0,0,16,16H96a24,24,0,0,1,24,24,8,8,0,0,0,16,0,24,24,0,0,1,24-24h72a16,16,0,0,0,16-16V64A16,16,0,0,0,232,48ZM96,192H24V64H96a24,24,0,0,1,24,24V200A39.81,39.81,0,0,0,96,192Zm136,0H160a39.81,39.81,0,0,0-24,8V88a24,24,0,0,1,24-24h72Z" ]
 
 
 {-| sliders-horizontal — the component-settings glyph in the Inspector.

--- a/src/Component/Ui.elm
+++ b/src/Component/Ui.elm
@@ -136,13 +136,15 @@ controlWidth =
     style "width" "180px"
 
 
+{-| Base attributes for the inspector's input controls (text fields, selects).
+The box chrome and interaction states (border, radius, padding, background,
+hover, focus, disabled) are owned by the `cp-control` class in the application
+shell stylesheet, so they are token-driven and stay consistent with the rest of
+the Inspector. Here we add only the control's typography (theme-driven).
+-}
 inputStyles : Theme -> List (Attribute msg)
 inputStyles theme =
-    [ style "border-radius" "8px"
-    , style "padding" "6px 12px"
-    , style "border" ("1px solid " ++ theme.dividerColor)
-    ]
-        ++ textStyles theme
+    Attributes.class "cp-control" :: textStyles theme
 
 
 textField :
@@ -167,14 +169,15 @@ textField theme c =
         ( attrs, errorBit ) =
             case c.error of
                 Just err ->
+                    -- An inline border overrides the cp-control class border, so
+                    -- the error outline wins over the themed default.
                     ( [ style "border" ("2px solid " ++ theme.errorColor) ]
                     , [ Html.div (textStyles theme ++ [ style "font-style" "italic", style "margin-right" "8px", style "color" theme.errorColor ]) [ Html.text err ] ]
                     )
 
                 Nothing ->
-                    ( [ style "border" ("1px solid " ++ theme.dividerColor) ]
-                    , []
-                    )
+                    -- No inline border: the cp-control class owns the box chrome.
+                    ( [], [] )
 
         input =
             Html.input
@@ -183,7 +186,6 @@ textField theme c =
                       , Attributes.id c.id
                       , Attributes.value c.value
                       , Events.onInput c.msg
-                      , style "background-color" theme.backgroundColor
                       , style "margin-left" "8px"
                       , style "flex-shrink" "0"
                       , controlWidth
@@ -239,8 +241,6 @@ select theme c =
                 (inputStyles theme
                     ++ [ Attributes.id c.id
                        , style "margin-left" "8px"
-                       , style "background-color" theme.backgroundColor
-                       , style "padding" "8px"
                        , Events.onInput c.msg
                        , Attributes.value value
                        , controlWidth


### PR DESCRIPTION
Review surface for the component-playground changes pinned by sage PR indicatrix/sage#1927 (Dicko's daily design branch). The sage repo consumes this library as a flake input (`js/lib/component-playground` is a gitignored nix symlink), so this is where the actual library diff is reviewable.

Pinned at `aa9df02`.

## What's in this branch (vs `main`)

**Shell / chrome**
- Navigation sidebar, top ribbon (breadcrumbs + Inspector trigger), full-height push-in Inspector.
- Sidebar redrawn to the design reference: tinted surface, Phosphor leading glyphs, consistent indentation, the category containing the selection turns accent-blue, selected page gets a soft-blue pill + bold label + accent dot (fill rules `!important` so they beat `Ui.button`'s inline background), muted chevrons.
- Phosphor regular icon set replaces the lucide stroked icons across all generic chrome (`Component.Ui`, default logo in `Theme`). Host-supplied product/brand icons untouched.
- Top ribbon hides the Inspector trigger while the panel is open.

**Inspector**
- Component metadata first, then settings, then design tokens.
- **Component-aware Design Tokens**: new `Component.withTokens` / `Component.tokenGroup` API attaches a component's real token usage (grouped) to its definition, threaded `Frame → ComponentE → Inspectable`. The Inspector renders only the selected component's categories (collapsed by default, read-only, per-category counts); no global static list. Token open/closed tracked as `expandedTokens`.

**Page structure (global)**
- Configurable pages lead with the live component inside a **Playground callout** (Playground icon + title header inside the preview surface, component left-aligned below), with all specimens/variant charts/usage notes moved below under a single **Reference** section. Explanatory bullet lists no longer sit above the live component. Pure token pages (no live component) render unchanged.

**Search panel**
- Bottom divider matching the header; in-field Phosphor clear (X) shown only with text, clears + keeps focus (mouse via mousedown preventDefault, keyboard via Escape), resets filtering.

**Specimens**
- "Variants & states" is an open, table-like reference (no grey box); the contained Playground callout keeps its border/elevation for contrast.

## Verification
- `cd examples && elm make src/Index.elm` compiles.
- `elm-format --validate src/` clean.
- `elm-test` — 109/109 pass.
- Verified in the running sage app at `/dev/components` across Button pages, Toast, Progress Spinner, Sliders, Dropdown, Marketing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)